### PR TITLE
fix(functions): managed identity for storage + Flex Consumption migration

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -202,15 +202,16 @@ jobs:
         run: |
           if ! az functionapp show --name ${{ env.AZURE_FUNCTIONAPP_NAME }} --resource-group ${{ env.AZURE_FUNCTIONAPP_RG }} >/dev/null 2>&1; then
             echo "⚠️ Function App ${{ env.AZURE_FUNCTIONAPP_NAME }} not found. Skipping function deploy."
-            exit 0
+            echo "skip=true" >> $GITHUB_OUTPUT
           fi
-          cd ./artifacts/functions
-          zip -r ../functions.zip . >/dev/null
-          cd ..
-          az functionapp deployment source config-zip \
-            --resource-group ${{ env.AZURE_FUNCTIONAPP_RG }} \
-            --name ${{ env.AZURE_FUNCTIONAPP_NAME }} \
-            --src ./functions.zip
+        id: check-func
+
+      - name: 🧮 Deploy CaseGen.Functions (RBAC)
+        if: steps.check-func.outputs.skip != 'true'
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          package: ./artifacts/functions
 
       - name: 🌐 Deploy Frontend to Azure Static Web Apps
         uses: Azure/static-web-apps-deploy@v1

--- a/functions/CaseGen.Functions/Program.cs
+++ b/functions/CaseGen.Functions/Program.cs
@@ -86,35 +86,9 @@ builder.Services
     {
         var configuration = serviceProvider.GetRequiredService<IConfiguration>();
         var logger = serviceProvider.GetRequiredService<ILogger<ContextManager>>();
-        
-        // Read connection string - handle both formats
-        var connectionString = configuration["CaseGeneratorStorage__ConnectionString"];
-        
-        if (string.IsNullOrWhiteSpace(connectionString))
-        {
-            // Fallback to AzureWebJobsStorage if not found
-            connectionString = configuration["AzureWebJobsStorage"];
-        }
-        
-        if (string.IsNullOrWhiteSpace(connectionString))
-        {
-            throw new InvalidOperationException(
-                "CaseGeneratorStorage__ConnectionString is not configured. " +
-                "Please set it in local.settings.json or environment variables.");
-        }
-        
-        logger.LogInformation("Initializing ContextManager with connection string format: {Format}", 
-            connectionString.StartsWith("UseDevelopmentStorage") ? "Development Storage" : "Custom");
-        
-        // Convert "UseDevelopmentStorage=true" to full connection string for modern SDK
-        if (connectionString.Equals("UseDevelopmentStorage=true", StringComparison.OrdinalIgnoreCase))
-        {
-            connectionString = "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
-            logger.LogInformation("Converted to Azurite connection string");
-        }
-        
-        var blobServiceClient = new BlobServiceClient(connectionString);
-        
+
+        var blobServiceClient = BlobServiceClientFactory.Create(configuration);
+
         // Use a dedicated container for context storage
         return new ContextManager(blobServiceClient, logger, containerName: "case-context");
     })

--- a/functions/CaseGen.Functions/Services/BlobServiceClientFactory.cs
+++ b/functions/CaseGen.Functions/Services/BlobServiceClientFactory.cs
@@ -1,0 +1,49 @@
+using Azure.Identity;
+using Azure.Storage.Blobs;
+using Microsoft.Extensions.Configuration;
+
+namespace CaseGen.Functions.Services;
+
+/// <summary>
+/// Centralised factory for <see cref="BlobServiceClient"/>.
+/// Prefers managed identity (CaseGeneratorStorage:AccountName) and falls back
+/// to connection strings (CaseGeneratorStorage:ConnectionString, AzureWebJobsStorage)
+/// to keep local dev with Azurite working without code changes.
+/// </summary>
+public static class BlobServiceClientFactory
+{
+    private const string AzuriteConnectionString =
+        "AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1;";
+
+    public static BlobServiceClient Create(IConfiguration configuration)
+    {
+        var accountName = configuration["CaseGeneratorStorage:AccountName"]
+            ?? configuration["CaseGeneratorStorage__AccountName"];
+
+        if (!string.IsNullOrWhiteSpace(accountName))
+        {
+            var uri = new Uri($"https://{accountName}.blob.core.windows.net");
+            return new BlobServiceClient(uri, new DefaultAzureCredential());
+        }
+
+        var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
+            ?? configuration["CaseGeneratorStorage__ConnectionString"]
+            ?? configuration["AzureWebJobsStorage"]
+            ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            throw new InvalidOperationException(
+                "Storage not configured. Set CaseGeneratorStorage:AccountName (managed identity, " +
+                "preferred for Azure) or CaseGeneratorStorage:ConnectionString / AzureWebJobsStorage " +
+                "(connection string, used for Azurite/local dev).");
+        }
+
+        if (connectionString.Equals("UseDevelopmentStorage=true", StringComparison.OrdinalIgnoreCase))
+        {
+            connectionString = AzuriteConnectionString;
+        }
+
+        return new BlobServiceClient(connectionString);
+    }
+}

--- a/functions/CaseGen.Functions/Services/CaseLoggingService.cs
+++ b/functions/CaseGen.Functions/Services/CaseLoggingService.cs
@@ -23,12 +23,7 @@ public class CaseLoggingService : ICaseLoggingService
 
     public CaseLoggingService(IConfiguration configuration, ILogger<CaseLoggingService> logger)
     {
-        var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
-            ?? configuration["AzureWebJobsStorage"]
-            ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
-            ?? throw new InvalidOperationException("Storage connection string not configured");
-
-        _blobServiceClient = new BlobServiceClient(connectionString);
+        _blobServiceClient = BlobServiceClientFactory.Create(configuration);
         _logger = logger;
         _logsContainer = "logs";
     }

--- a/functions/CaseGen.Functions/Services/StorageService.cs
+++ b/functions/CaseGen.Functions/Services/StorageService.cs
@@ -13,13 +13,7 @@ public class StorageService : IStorageService
 
     public StorageService(IConfiguration configuration, ILogger<StorageService> logger)
     {
-        // Prefer specific CaseGenerator setting; fall back to AzureWebJobsStorage (local.settings / App Settings)
-        var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
-            ?? configuration["AzureWebJobsStorage"]
-            ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
-            ?? throw new InvalidOperationException("Storage connection string not configured. Set CaseGeneratorStorage:ConnectionString or AzureWebJobsStorage.");
-
-        _blobServiceClient = new BlobServiceClient(connectionString);
+        _blobServiceClient = BlobServiceClientFactory.Create(configuration);
         _logger = logger;
     }
 


### PR DESCRIPTION
## Summary

Migrates `casegen-func-dev` to **Flex Consumption (FC1)** with full managed identity for storage, fixing the deploy failure on PR #119 (`KeyBasedAuthenticationNotPermitted`).

## Code changes
- New `BlobServiceClientFactory.Create` (prefers `CaseGeneratorStorage:AccountName` + `DefaultAzureCredential`; falls back to connection string for Azurite local dev).
- `StorageService`, `CaseLoggingService`, `Program.cs` (ContextManager registration) updated to use the factory.

## CI changes
- `cd-dev.yml`: deploy Functions via `Azure/functions-action@v1` (RBAC-based via the existing `azure/login`), replacing the legacy `az functionapp deployment source config-zip` that required shared key access.

## Azure infra (done out-of-band, here for visibility)
- Deleted old `casegen-func-dev` + Y1 plan.
- Created new Flex Consumption (FC1) plan + function app (same name) in canadacentral, `dotnet-isolated` 9.0, 2048 MB.
- System-assigned managed identity enabled. Role assignments on storage `stcadevcabtlmvw4g`:
  - Storage Blob Data Owner, Storage Queue Data Contributor, Storage Table Data Contributor
- Key Vault `kv-ca-dev-oeq4agkmf6k4k`: granted `Key Vault Secrets User` to the identity.
- App settings: identity-based (`AzureWebJobsStorage__accountName`, `CaseGeneratorStorage__AccountName`), no connection strings. KV references for AzureOpenAI re-applied.
- Deployment package container: `deploymentpackage` (identity-auth).