### PR TITLE
feat(task-4): backend MI storage migration + Bicep IaC alignment + ResolveCasesBasePath fix

### DIFF
--- a/backend/CaseZeroApi.IntegrationTests/CustomWebApplicationFactory.cs
+++ b/backend/CaseZeroApi.IntegrationTests/CustomWebApplicationFactory.cs
@@ -122,7 +122,11 @@ namespace CaseZeroApi.IntegrationTests
                     // Force the storage service to read fixture cases from the repo's cases/
                     // folder regardless of where the test host's content root happens to point.
                     ["CaseGenV2:LocalCasesPath"] = Path.Combine(ResolveRepoRoot(), "cases"),
-                    ["CaseGeneratorStorage:ConnectionString"] = "UseDevelopmentStorage=true"
+                    ["CaseGeneratorStorage:ConnectionString"] = "UseDevelopmentStorage=true",
+                    // Explicitly blank the MI account name so tests always take the
+                    // connection-string path (Azurite-style) even if a developer has
+                    // CaseGeneratorStorage__AccountName set in their environment.
+                    ["CaseGeneratorStorage:AccountName"] = ""
                 });
             });
         }

--- a/backend/CaseZeroApi/CaseZeroApi.csproj
+++ b/backend/CaseZeroApi/CaseZeroApi.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCoreRateLimit" Version="5.0.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />

--- a/backend/CaseZeroApi/Controllers/AssetsController.cs
+++ b/backend/CaseZeroApi/Controllers/AssetsController.cs
@@ -6,6 +6,7 @@ using CaseZeroApi.Data;
 using CaseZeroApi.DTOs;
 using CaseZeroApi.Models;
 using CaseZeroApi.Services;
+using Azure.Core;
 using Azure.Storage.Blobs;
 
 namespace CaseZeroApi.Controllers
@@ -27,7 +28,8 @@ namespace CaseZeroApi.Controllers
             ILogger<AssetsController> logger,
             IConfiguration configuration,
             IAuditLogService auditLogService, // P86
-            ICaseV2StorageService caseStorageService) // v2
+            ICaseV2StorageService caseStorageService, // v2
+            TokenCredential credential)
         {
             _context = context;
             _logger = logger;
@@ -35,12 +37,9 @@ namespace CaseZeroApi.Controllers
             _auditLogService = auditLogService; // P86
             _caseStorageService = caseStorageService; // P87
 
-            // Initialize BlobServiceClient for direct blob access
-            var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
-                ?? configuration["AzureWebJobsStorage"]
-                ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
-                ?? "UseDevelopmentStorage=true";
-            _blobServiceClient = new BlobServiceClient(connectionString);
+            // Prefer managed identity when CaseGeneratorStorage:AccountName is set;
+            // fall back to connection string for local dev (Azurite).
+            _blobServiceClient = CaseGeneratorStorageFactory.CreateBlobServiceClient(configuration, credential);
         }
 
         /// <summary>

--- a/backend/CaseZeroApi/Controllers/EmailsController.cs
+++ b/backend/CaseZeroApi/Controllers/EmailsController.cs
@@ -6,6 +6,7 @@ using CaseZeroApi.Data;
 using CaseZeroApi.DTOs;
 using CaseZeroApi.Models;
 using CaseZeroApi.Services;
+using Azure.Core;
 using Azure.Storage.Blobs;
 
 namespace CaseZeroApi.Controllers
@@ -31,7 +32,8 @@ namespace CaseZeroApi.Controllers
             IConfiguration configuration,
             IAuditLogService auditLogService, // P86
             IVisibilityService visibilityService, // Asset unlock
-            IRulesEngineService rulesEngine)
+            IRulesEngineService rulesEngine,
+            TokenCredential credential)
         {
             _context = context;
             _logger = logger;
@@ -40,13 +42,10 @@ namespace CaseZeroApi.Controllers
             _auditLogService = auditLogService; // P86
             _visibilityService = visibilityService; // Asset unlock
             _rulesEngine = rulesEngine;
-            
-            // Initialize BlobServiceClient for attachment downloads
-            var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
-                ?? configuration["AzureWebJobsStorage"]
-                ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
-                ?? "UseDevelopmentStorage=true";
-            _blobServiceClient = new BlobServiceClient(connectionString);
+
+            // Prefer managed identity when CaseGeneratorStorage:AccountName is set;
+            // fall back to connection string for local dev (Azurite).
+            _blobServiceClient = CaseGeneratorStorageFactory.CreateBlobServiceClient(configuration, credential);
         }
 
         /// <summary>

--- a/backend/CaseZeroApi/Program.cs
+++ b/backend/CaseZeroApi/Program.cs
@@ -1,4 +1,6 @@
 using System.Text;
+using Azure.Core;
+using Azure.Identity;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -200,6 +202,10 @@ builder.Services.AddScoped<DataSeedingService>();
 
 // Case storage (v2)
 builder.Services.AddMemoryCache();
+// Shared TokenCredential for managed identity. DefaultAzureCredential caches
+// tokens internally — register as singleton so the token cache is reused across
+// every scoped request that hits Azure Storage.
+builder.Services.AddSingleton<TokenCredential>(_ => new DefaultAzureCredential());
 builder.Services.AddScoped<ICaseV2SanitizerService, CaseV2SanitizerService>();
 builder.Services.AddScoped<ICaseV2StorageService, CaseV2StorageService>();
 builder.Services.AddScoped<ISolutionService, SolutionService>();

--- a/backend/CaseZeroApi/Services/CaseGeneratorStorageFactory.cs
+++ b/backend/CaseZeroApi/Services/CaseGeneratorStorageFactory.cs
@@ -1,0 +1,62 @@
+using Azure.Core;
+using Azure.Storage.Blobs;
+using Azure.Storage.Queues;
+
+namespace CaseZeroApi.Services;
+
+/// <summary>
+/// Centralised factory for Azure Storage clients used by the API to read
+/// case bundles published by the Function App and to enqueue forensic work.
+///
+/// Prefers managed identity (when <c>CaseGeneratorStorage:AccountName</c>
+/// is configured) and falls back to connection strings for local dev where
+/// Azurite or the legacy AzureWebJobsStorage key is still in play.
+///
+/// Pattern mirrors <c>BlobServiceClientFactory</c> in the CaseGen.Functions
+/// project so the two halves of the system stay consistent.
+/// </summary>
+public static class CaseGeneratorStorageFactory
+{
+    private const string AzuriteConnectionString = "UseDevelopmentStorage=true";
+
+    public static BlobServiceClient CreateBlobServiceClient(
+        IConfiguration configuration,
+        TokenCredential credential)
+    {
+        var accountName = ResolveAccountName(configuration);
+        if (!string.IsNullOrWhiteSpace(accountName))
+        {
+            var uri = new Uri($"https://{accountName}.blob.core.windows.net");
+            return new BlobServiceClient(uri, credential);
+        }
+
+        return new BlobServiceClient(ResolveConnectionString(configuration));
+    }
+
+    public static QueueClient CreateQueueClient(
+        IConfiguration configuration,
+        TokenCredential credential,
+        string queueName)
+    {
+        var accountName = ResolveAccountName(configuration);
+        if (!string.IsNullOrWhiteSpace(accountName))
+        {
+            var uri = new Uri($"https://{accountName}.queue.core.windows.net/{queueName}");
+            return new QueueClient(uri, credential);
+        }
+
+        return new QueueClient(ResolveConnectionString(configuration), queueName);
+    }
+
+    public static bool UsesManagedIdentity(IConfiguration configuration)
+        => !string.IsNullOrWhiteSpace(ResolveAccountName(configuration));
+
+    private static string? ResolveAccountName(IConfiguration configuration)
+        => configuration["CaseGeneratorStorage:AccountName"];
+
+    private static string ResolveConnectionString(IConfiguration configuration)
+        => configuration["CaseGeneratorStorage:ConnectionString"]
+            ?? configuration["AzureWebJobsStorage"]
+            ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
+            ?? AzuriteConnectionString;
+}

--- a/backend/CaseZeroApi/Services/CaseV2StorageService.cs
+++ b/backend/CaseZeroApi/Services/CaseV2StorageService.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Azure.Core;
 using Azure.Storage.Blobs;
 using CaseZeroApi.Models.CaseV2;
 using Microsoft.Extensions.Caching.Memory;
@@ -26,14 +27,10 @@ public class CaseV2StorageService : ICaseV2StorageService
         ICaseV2SanitizerService sanitizer,
         ILogger<CaseV2StorageService> logger,
         IMemoryCache cache,
-        IWebHostEnvironment env)
+        IWebHostEnvironment env,
+        TokenCredential credential)
     {
-        var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
-            ?? configuration["AzureWebJobsStorage"]
-            ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
-            ?? "UseDevelopmentStorage=true";
-
-        _blobServiceClient = new BlobServiceClient(connectionString);
+        _blobServiceClient = CaseGeneratorStorageFactory.CreateBlobServiceClient(configuration, credential);
         _sanitizer = sanitizer;
         _logger = logger;
         _cache = cache;
@@ -45,7 +42,12 @@ public class CaseV2StorageService : ICaseV2StorageService
         // before the SDK gives up. The dev override appsettings.Local.json sets this to
         // false so the dashboard just uses the filesystem. Production keeps it on.
         _useBlobStorage = configuration.GetValue("CaseGenV2:UseBlobStorage", true);
-        _logger.LogInformation("CaseV2StorageService _useBlobStorage = {Value}", _useBlobStorage);
+        var authMode = CaseGeneratorStorageFactory.UsesManagedIdentity(configuration)
+            ? "ManagedIdentity"
+            : "ConnectionString";
+        _logger.LogInformation(
+            "CaseV2StorageService initialised. UseBlobStorage={UseBlobStorage} Auth={Auth} Container={Container}",
+            _useBlobStorage, authMode, _bundlesContainer);
     }
 
     public async Task<List<CaseV2Metadata2>> ListCasesAsync(CancellationToken ct = default)
@@ -83,7 +85,10 @@ public class CaseV2StorageService : ICaseV2StorageService
             try
             {
                 var container = _blobServiceClient.GetBlobContainerClient(_bundlesContainer);
-                await container.CreateIfNotExistsAsync(cancellationToken: ct);
+                // NOTE: deliberately do NOT call CreateIfNotExistsAsync here. The API
+                // uses a least-privilege Storage Blob Data Reader role under managed
+                // identity, which cannot create containers. The bundles container is
+                // created by the Functions infrastructure (Bicep).
                 await foreach (var item in container.GetBlobsByHierarchyAsync(delimiter: "/", cancellationToken: ct))
                 {
                     if (!item.IsPrefix) continue;

--- a/backend/CaseZeroApi/Services/ForensicQueueService.cs
+++ b/backend/CaseZeroApi/Services/ForensicQueueService.cs
@@ -1,3 +1,4 @@
+using Azure.Core;
 using Azure.Storage.Queues;
 using System.Text.Json;
 
@@ -5,7 +6,8 @@ namespace CaseZeroApi.Services;
 
 /// <summary>
 /// Service for enqueuing forensic analysis requests to Azure Storage Queue.
-/// Uses the same storage account as BlobStorageService (Azurite for local dev).
+/// Uses the same storage account as the case bundles (managed identity in Azure,
+/// connection string / Azurite locally).
 /// </summary>
 public class ForensicQueueService : IForensicQueueService
 {
@@ -13,19 +15,19 @@ public class ForensicQueueService : IForensicQueueService
     private readonly ILogger<ForensicQueueService> _logger;
     private const string QUEUE_NAME = "forensic-requests";
 
-    public ForensicQueueService(IConfiguration configuration, ILogger<ForensicQueueService> logger)
+    public ForensicQueueService(
+        IConfiguration configuration,
+        ILogger<ForensicQueueService> logger,
+        TokenCredential credential)
     {
         _logger = logger;
 
-        // Same connection string logic as BlobStorageService
-        var connectionString = configuration["CaseGeneratorStorage:ConnectionString"]
-            ?? configuration["AzureWebJobsStorage"]
-            ?? Environment.GetEnvironmentVariable("AzureWebJobsStorage")
-            ?? "UseDevelopmentStorage=true"; // Azurite default
+        _queueClient = CaseGeneratorStorageFactory.CreateQueueClient(configuration, credential, QUEUE_NAME);
 
-        _queueClient = new QueueClient(connectionString, QUEUE_NAME);
-
-        // Create queue if it doesn't exist (safe for Azurite and Azure)
+        // Best-effort queue creation. With least-privilege MI (Storage Queue Data
+        // Message Sender) the create call returns 403 — that's fine as long as the
+        // queue has been pre-provisioned (Bicep creates it). Swallowing the
+        // exception keeps app startup resilient regardless of the auth model.
         try
         {
             _queueClient.CreateIfNotExists();
@@ -33,8 +35,11 @@ public class ForensicQueueService : IForensicQueueService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to initialize forensic queue: {QueueName}", QUEUE_NAME);
-            throw;
+            _logger.LogWarning(ex,
+                "CreateIfNotExists failed for queue {QueueName}. This is expected when running with " +
+                "least-privilege managed identity (queue must be pre-provisioned). Send will fail if " +
+                "the queue does not exist.",
+                QUEUE_NAME);
         }
     }
 

--- a/backlog/BACKLOG.md
+++ b/backlog/BACKLOG.md
@@ -6,7 +6,75 @@
 
 ## 🔥 Em aberto
 
+### TASK 5 — Migrar `AzureWebJobsStorage` da Function App para Managed Identity completo
+
+Descoberto durante a TASK 4 (rubber-duck review). O Bicep da Function App em
+`infrastructure/functions/main.bicep` ainda usa `listKeys()` + connection
+string em `AzureWebJobsStorage` e `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING`.
+Hoje funciona em dev porque setamos `AzureWebJobsStorage__accountName` direto
+via `az` (drift), mas se alguém re-provisionar com o Bicep atual numa
+subscription com a policy `Azure_Security_Baseline` (que bloqueia
+`allowSharedKeyAccess`), a Function App não sobe — o `listKeys()` durante o
+deploy do storage falha ou as connection strings ficam inertes.
+
+**Bloqueio técnico:** o plano `Y1 (Consumption)` exige
+`WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` para o content share, e essa
+chave **só** funciona com connection string (não tem MI no Y1). Migrar para
+MI completa exige mudar o plano para **Flex Consumption** (`FC1`) ou
+**Elastic Premium** (`EP1`).
+
+**Tarefas:**
+
+1. Mudar `infrastructure/functions/main.bicep` para `FC1` (Flex Consumption)
+   em dev ou aceitar `EP1` (mais caro).
+2. Substituir `AzureWebJobsStorage` (connection string) por
+   `AzureWebJobsStorage__accountName=<storage>` + `AzureWebJobsStorage__credential=managedidentity`.
+3. Remover `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` + `WEBSITE_CONTENTSHARE`
+   (Flex Consumption não usa content share — usa deployment package via
+   `WEBSITE_RUN_FROM_PACKAGE` ou o novo `linuxFxVersion` com source de pacote).
+4. Garantir que o MI da FA tem `Storage Blob Data Owner` (ou
+   `Contributor`) no storage account para conseguir gerenciar lease/leases
+   do host.
+5. Validar com `azd up` + smoke da geração ponta-a-ponta numa subscription
+   com a policy ativa.
+
+**Critério de aceitação:** Recriar do zero (`azd up`) numa subscription com
+`Azure_Security_Baseline` ativo, e a Function App subir, processar uma
+geração v2 e publicar o caso no blob — sem nenhum `az ... appsettings set`
+manual e sem nenhuma chave compartilhada habilitada.
+
 ### TASK 4 — Persistir configuração da Function App no Bicep + corrigir fallback de disco
+
+**Status:** Implementação concluída em `feat/task-4-bicep-mi-fallback` (PR
+em aberto). Após o merge + deploy do código via CI, ainda faltam os passos
+**manuais** em Azure dev (até o Bicep ser re-aplicado por `azd provision`):
+
+```bash
+# 1. Atribuir RBAC do API MI no storage account (cross-RG)
+API_MI=$(az webapp identity show -n casezero-api-dev -g casezero-api-dev-rg --query principalId -o tsv)
+STORAGE_ID=$(az storage account show -n stcadevcabtlmvw4g -g casezero-func-dev-rg --query id -o tsv)
+az role assignment create --assignee-object-id $API_MI --assignee-principal-type ServicePrincipal \
+  --role "Storage Blob Data Reader" --scope $STORAGE_ID
+az role assignment create --assignee-object-id $API_MI --assignee-principal-type ServicePrincipal \
+  --role "Storage Queue Data Message Sender" --scope $STORAGE_ID
+
+# 2. Pré-criar a queue forensic-requests (o Bicep faz no provision; em dev cria manualmente)
+az storage queue create --name forensic-requests --account-name stcadevcabtlmvw4g --auth-mode login
+
+# 3. Trocar a connection string pelo AccountName no Web App
+az webapp config appsettings set -n casezero-api-dev -g casezero-api-dev-rg \
+  --settings CaseGeneratorStorage__AccountName=stcadevcabtlmvw4g
+az webapp config appsettings delete -n casezero-api-dev -g casezero-api-dev-rg \
+  --setting-names CaseGeneratorStorage__ConnectionString
+
+# 4. Remover o override de CasesBasePath na FA (o código agora usa /tmp/casegen como fallback)
+az functionapp config appsettings delete -n casegen-func-dev -g casezero-func-dev-rg \
+  --setting-names CaseGenV2__CasesBasePath
+```
+
+Aguardar 5–10 min após RBAC para propagação e testar dashboard.
+
+---
 
 Durante o TASK 3 (validar geração ponta-a-ponta em Azure dev) aplicamos uma
 série de mudanças direto no Azure via `az` que **não** estão no IaC do repo.

--- a/backlog/BACKLOG.md
+++ b/backlog/BACKLOG.md
@@ -29,6 +29,14 @@ para Flex Consumption Linux.
 
 `infrastructure/api/main.bicep` (Web App `casezero-api-dev`):
 - Faltando: `CaseGenerator__FunctionBaseUrl=https://<func-app>.azurewebsites.net`
+- Faltando: `CaseGeneratorStorage__ConnectionString` apontando para a storage
+  account `stcadevcabtlmvw4g`. Sem isso, `CaseV2StorageService` cai pra
+  `UseDevelopmentStorage=true` (Azurite) e a `/api/cases` lista vazio
+  silenciosamente — geração funciona, blobs ficam em `bundles/<caseId>/`,
+  mas o dashboard nunca vê o caso novo.
+- Faltando: `CaseGeneratorStorage__BundlesContainer=bundles` e
+  `CaseGeneratorStorage__CasesContainer=cases` (defaults do código já são
+  `bundles`/`cases` mas vale declarar explicitamente para consistência com a FA).
 
 `infrastructure/README.md`:
 - Ainda documenta `AzureOpenAI__*` em vez de `AzureFoundry__*`.
@@ -61,17 +69,41 @@ Windows local e macOS local sem precisar de app setting em prod.
    - Adicionar app setting `CaseGenerator__FunctionBaseUrl` derivado do
      nome/host da Function App do mesmo deploy (parametrizar ou ler da
      output do módulo de functions).
+   - Adicionar `CaseGeneratorStorage__ConnectionString`,
+     `CaseGeneratorStorage__BundlesContainer=bundles` e
+     `CaseGeneratorStorage__CasesContainer=cases`. Em dev pode ser connection
+     string da storage account `stcadevcabtlmvw4g` (que já foi aplicada via
+     `az` nesta sessão como workaround). Em prod **prefira o item 5 abaixo**
+     (migrar para Managed Identity).
 
 3. `infrastructure/README.md`:
    - Atualizar a seção de app settings da Function App para listar
      `AzureFoundry__*` em vez de `AzureOpenAI__*` e mencionar
      `CaseGenV2__CasesBasePath` + `LLM__UseAzureFoundry`.
+   - Adicionar seção de app settings do Web App com `CaseGenerator__FunctionBaseUrl`
+     e `CaseGeneratorStorage__*`.
 
 4. Código — `CaseV2GeneratorService.ResolveCasesBasePath`:
    - Trocar fallback final de `Path.Combine(AppContext.BaseDirectory, "cases")`
      para `Path.Combine(Path.GetTempPath(), "casegen")`.
    - Manter walk-up para repo-root só quando rodando local (preservar DX local).
    - Depois disso, `CaseGenV2__CasesBasePath=/tmp` pode sair do Bicep.
+
+5. Código — `CaseV2StorageService` migrar para Managed Identity (igual à FA):
+   - Hoje só lê `CaseGeneratorStorage:ConnectionString` (connection string com
+     account key). A FA já usa `AzureWebJobsStorage__accountName` +
+     `DefaultAzureCredential`.
+   - Adicionar suporte a `CaseGeneratorStorage:AccountName` no construtor:
+     se setado, usar `new BlobServiceClient(new Uri($"https://{accountName}.blob.core.windows.net"), new DefaultAzureCredential())`.
+     Senão, manter fallback atual pra connection string (preserva DX local com Azurite).
+   - Aplicar o mesmo padrão em `AssetsController`, `EmailsController` e
+     `ForensicQueueService` (todos buscam `CaseGeneratorStorage:ConnectionString`
+     direto hoje).
+   - Habilitar System-Assigned MI no Web App via Bicep e dar role
+     `Storage Blob Data Reader` (ou `Contributor` se houver write) no escopo
+     da storage account.
+   - Depois disso, `CaseGeneratorStorage__ConnectionString` pode sair do Bicep
+     do Web App; só fica `CaseGeneratorStorage__AccountName`.
 
 **Notas:**
 
@@ -88,9 +120,11 @@ Windows local e macOS local sem precisar de app setting em prod.
 **Critério de aceitação:**
 
 - Rodar `az deployment ... what-if` ou `azd provision` na branch e ver que
-  as 4 mudanças acima ficaram aplicadas sem drift.
+  as 5 mudanças acima ficaram aplicadas sem drift.
 - Geração ponta-a-ponta continua funcionando após o deploy do Bicep (sem
   precisar de `az ... appsettings set` manual).
+- Dashboard do Web App lista o caso recém-gerado **sem** depender de
+  connection string com account key (se item 5 foi feito).
 - Em outra sub/ambiente novo, `azd up` deixa tudo funcionando do zero
   (assumindo que os 4 secrets do AzureFoundry sejam pré-populados no KV ou
   criados pelo próprio Bicep).

--- a/functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs
@@ -560,8 +560,11 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
             dir = dir.Parent;
         }
 
-        // Fallback: create alongside the binary.
-        var fallback = Path.Combine(AppContext.BaseDirectory, "cases");
+        // Fallback when nothing else exists. Use the OS temp dir so we never try
+        // to write under the deployment-package mount (e.g. /home/site/wwwroot
+        // on Linux Function Apps, which is read-only). Works on Windows, macOS
+        // and Linux without per-environment app settings.
+        var fallback = Path.Combine(Path.GetTempPath(), "casegen");
         Directory.CreateDirectory(fallback);
         return fallback;
     }

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -169,15 +169,29 @@ ConnectionStrings__DefaultConnection=Data Source=casezero.db (SQLite) or SQL Ser
 JwtSettings__SecretKey=@Microsoft.KeyVault(SecretUri=...)
 APPINSIGHTS_INSTRUMENTATIONKEY=<auto>
 APPLICATIONINSIGHTS_CONNECTION_STRING=<auto>
+CaseGenerator__FunctionBaseUrl=https://<func-app>.azurewebsites.net
+CaseGeneratorStorage__AccountName=<storage-account>           # managed identity
+CaseGeneratorStorage__BundlesContainer=bundles
+CaseGeneratorStorage__CasesContainer=cases
 ```
+
+The API uses System-Assigned Managed Identity to read case bundles
+(`Storage Blob Data Reader`) and to enqueue forensic requests
+(`Storage Queue Data Message Sender`). The `forensic-requests` queue is
+pre-created by the functions layer so the API runs with least-privilege RBAC.
 
 #### Functions (.NET 9.0)
 ```
 FUNCTIONS_EXTENSION_VERSION=~4
 FUNCTIONS_WORKER_RUNTIME=dotnet-isolated
-CaseGeneratorStorage__ConnectionString=<auto>
-AzureOpenAI__Endpoint=@Microsoft.KeyVault(SecretUri=...)
-AzureOpenAI__ApiKey=@Microsoft.KeyVault(SecretUri=...)
+CaseGeneratorStorage__AccountName=<storage-account>           # managed identity
+CaseGeneratorStorage__BundlesContainer=bundles
+CaseGeneratorStorage__CasesContainer=cases
+LLM__UseAzureFoundry=true
+AzureFoundry__Endpoint=@Microsoft.KeyVault(SecretUri=...)
+AzureFoundry__ApiKey=@Microsoft.KeyVault(SecretUri=...)
+AzureFoundry__ModelName=@Microsoft.KeyVault(SecretUri=...)
+AzureFoundry__ImageDeploymentName=@Microsoft.KeyVault(SecretUri=...)
 KeyVault__VaultUri=<auto>
 ```
 
@@ -199,21 +213,26 @@ az keyvault secret set \
   --name jwt-signing-key \
   --value "<generate-secure-key-32-chars>"
 
-# Azure OpenAI credentials
+# Azure AI Foundry credentials (used by the Case Generator)
 az keyvault secret set \
   --vault-name <keyvault-name> \
-  --name azure-openai-endpoint \
-  --value "https://<your-openai-resource>.openai.azure.com/"
+  --name azure-foundry-endpoint \
+  --value "https://<your-foundry-resource>.cognitiveservices.azure.com/"
 
 az keyvault secret set \
   --vault-name <keyvault-name> \
-  --name azure-openai-api-key \
+  --name azure-foundry-api-key \
   --value "<your-api-key>"
 
 az keyvault secret set \
   --vault-name <keyvault-name> \
-  --name azure-openai-deployment-name \
-  --value "gpt-4o"
+  --name azure-foundry-model-name \
+  --value "gpt-5.2"
+
+az keyvault secret set \
+  --vault-name <keyvault-name> \
+  --name azure-foundry-image-deployment-name \
+  --value "gpt-image-2"
 ```
 
 ## 📊 Cost Estimation

--- a/infrastructure/api/main.bicep
+++ b/infrastructure/api/main.bicep
@@ -47,6 +47,15 @@ param appInsightsInstrumentationKey string = ''
 @description('CORS allowed origins')
 param corsAllowedOrigins array = ['*']
 
+@description('Function App base URL the API proxies case-generation requests to (e.g. https://casegen-func-dev.azurewebsites.net). Wired from the functions layer output by the orchestrator.')
+param caseGeneratorFunctionBaseUrl string = ''
+
+@description('Storage Account name the API reads case bundles from via managed identity. Wired from the functions layer output by the orchestrator.')
+param caseGeneratorStorageAccountName string = ''
+
+@description('Storage Account Resource ID for the case bundles storage (used to scope the RBAC assignment cross-RG).')
+param caseGeneratorStorageAccountId string = ''
+
 var tags = {
   Environment: environment
   Project: 'CaseZero'
@@ -160,6 +169,22 @@ module apiAppService 'br/public:avm/res/web/site:0.14.0' = {
           name: 'IpRateLimiting__GeneralRules__0__Limit'
           value: environment == 'prod' ? '100' : '200'
         }
+        {
+          name: 'CaseGenerator__FunctionBaseUrl'
+          value: caseGeneratorFunctionBaseUrl
+        }
+        {
+          name: 'CaseGeneratorStorage__AccountName'
+          value: caseGeneratorStorageAccountName
+        }
+        {
+          name: 'CaseGeneratorStorage__BundlesContainer'
+          value: 'bundles'
+        }
+        {
+          name: 'CaseGeneratorStorage__CasesContainer'
+          value: 'cases'
+        }
       ]
       // Connection Strings
       connectionStrings: [
@@ -184,6 +209,24 @@ module keyVaultRoleAssignment 'keyvault-rbac.bicep' = {
     keyVaultId: keyVaultId
     principalId: apiAppService.outputs.systemAssignedMIPrincipalId!
     principalType: 'ServicePrincipal'
+  }
+}
+
+// ==============================================================================
+// RBAC - Grant API App Service access to Case Generator Storage
+// ==============================================================================
+// API reads case bundles (Storage Blob Data Reader) and enqueues forensic
+// requests (Storage Queue Data Message Sender — send-only, queue pre-created
+// by Bicep). Deployed cross-RG into the storage account's resource group.
+module storageRoleAssignment 'storage-rbac.bicep' = if (!empty(caseGeneratorStorageAccountId)) {
+  name: 'api-storage-rbac-deployment'
+  scope: resourceGroup(split(caseGeneratorStorageAccountId, '/')[2], split(caseGeneratorStorageAccountId, '/')[4])
+  params: {
+    storageAccountName: caseGeneratorStorageAccountName
+    principalId: apiAppService.outputs.systemAssignedMIPrincipalId!
+    principalType: 'ServicePrincipal'
+    assignBlobReader: true
+    assignQueueMessageSender: true
   }
 }
 

--- a/infrastructure/api/storage-rbac.bicep
+++ b/infrastructure/api/storage-rbac.bicep
@@ -1,0 +1,82 @@
+// ==============================================================================
+// Storage RBAC Assignment Module
+// ==============================================================================
+// Assigns Storage data-plane roles to a principal at the scope of an existing
+// Storage Account. Deploy this module at the resource group where the storage
+// account lives (cross-RG scope is supported from a caller in another RG).
+// ==============================================================================
+
+targetScope = 'resourceGroup'
+
+@description('Storage Account name (in the resource group this module is deployed to)')
+param storageAccountName string
+
+@description('Principal ID to grant access')
+param principalId string
+
+@description('Principal Type (ServicePrincipal for managed identities)')
+param principalType string = 'ServicePrincipal'
+
+@description('Assign Storage Blob Data Reader role')
+param assignBlobReader bool = true
+
+@description('Assign Storage Blob Data Contributor role (broader than Reader)')
+param assignBlobContributor bool = false
+
+@description('Assign Storage Queue Data Message Sender role (send-only)')
+param assignQueueMessageSender bool = true
+
+@description('Assign Storage Queue Data Contributor role (queue management + messages)')
+param assignQueueContributor bool = false
+
+// Built-in role IDs (data plane). Source: Azure built-in roles documentation.
+var roleIds = {
+  blobDataReader: '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+  blobDataContributor: 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+  queueDataMessageSender: 'c6a89b2d-59bc-44d0-9896-0f6e12d7b80a'
+  queueDataContributor: '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
+}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource blobReader 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (assignBlobReader) {
+  name: guid(storageAccount.id, principalId, roleIds.blobDataReader)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleIds.blobDataReader)
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+resource blobContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (assignBlobContributor) {
+  name: guid(storageAccount.id, principalId, roleIds.blobDataContributor)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleIds.blobDataContributor)
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+resource queueMessageSender 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (assignQueueMessageSender) {
+  name: guid(storageAccount.id, principalId, roleIds.queueDataMessageSender)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleIds.queueDataMessageSender)
+    principalId: principalId
+    principalType: principalType
+  }
+}
+
+resource queueContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = if (assignQueueContributor) {
+  name: guid(storageAccount.id, principalId, roleIds.queueDataContributor)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', roleIds.queueDataContributor)
+    principalId: principalId
+    principalType: principalType
+  }
+}

--- a/infrastructure/functions/main.bicep
+++ b/infrastructure/functions/main.bicep
@@ -39,6 +39,9 @@ param containerNames array = [
 @description('Key Vault URI from shared infrastructure')
 param keyVaultUri string
 
+@description('Key Vault Resource ID from shared infrastructure (used to grant the Function App MI access to secrets)')
+param keyVaultId string
+
 @description('Application Insights Connection String from shared infrastructure')
 param appInsightsConnectionString string = ''
 
@@ -186,6 +189,10 @@ module functionApp 'br/public:avm/res/web/site:0.14.0' = {
           value: storageConnectionString
         }
         {
+          name: 'CaseGeneratorStorage__AccountName'
+          value: storageAccountName
+        }
+        {
           name: 'CaseGeneratorStorage__CasesContainer'
           value: 'cases'
         }
@@ -202,20 +209,61 @@ module functionApp 'br/public:avm/res/web/site:0.14.0' = {
           value: 'CaseGeneratorHub'
         }
         {
-          name: 'AzureOpenAI__Endpoint'
-          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-openai-endpoint/)'
+          name: 'LLM__UseAzureFoundry'
+          value: 'true'
         }
         {
-          name: 'AzureOpenAI__ApiKey'
-          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-openai-api-key/)'
+          name: 'AzureFoundry__Endpoint'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-foundry-endpoint/)'
         }
         {
-          name: 'AzureOpenAI__DeploymentName'
-          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-openai-deployment-name/)'
+          name: 'AzureFoundry__ApiKey'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-foundry-api-key/)'
+        }
+        {
+          name: 'AzureFoundry__ModelName'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-foundry-model-name/)'
+        }
+        {
+          name: 'AzureFoundry__ImageDeploymentName'
+          value: '@Microsoft.KeyVault(SecretUri=${keyVaultUri}secrets/azure-foundry-image-deployment-name/)'
         }
       ]
     }
     tags: tags
+  }
+}
+
+// ==============================================================================
+// Forensic Request Queue
+// ==============================================================================
+// Pre-create the queue used by the API (ForensicQueueService) so the API can
+// run with least-privilege RBAC (Storage Queue Data Message Sender) without
+// needing queue-management permissions at startup.
+resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' = {
+  parent: existingStorageAccount
+  name: 'default'
+  dependsOn: [storageAccount]
+}
+
+resource forensicRequestsQueue 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = {
+  parent: queueService
+  name: 'forensic-requests'
+}
+
+// ==============================================================================
+// RBAC - Grant Function App MI access to Key Vault secrets
+// ==============================================================================
+// Shares the same module used by the API layer. The Function App's MI needs
+// "Key Vault Secrets User" so it can resolve the @Microsoft.KeyVault(...)
+// references in AzureFoundry__* app settings.
+module functionsKeyVaultRoleAssignment '../api/keyvault-rbac.bicep' = {
+  name: 'functions-keyvault-rbac-deployment'
+  scope: resourceGroup(split(keyVaultId, '/')[2], split(keyVaultId, '/')[4])
+  params: {
+    keyVaultId: keyVaultId
+    principalId: functionApp.outputs.systemAssignedMIPrincipalId!
+    principalType: 'ServicePrincipal'
   }
 }
 

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -112,6 +112,9 @@ module sharedInfrastructure 'shared/main.bicep' = {
 // ==============================================================================
 // Layer 2: API Backend Infrastructure
 // ==============================================================================
+// NOTE: this layer depends on the functions layer outputs (storage account +
+// function URL) so the API can talk to the Case Generator using managed
+// identity. The implicit dependency forces api to deploy after functions.
 module apiInfrastructure 'api/main.bicep' = {
   name: 'api-infrastructure-deployment'
   scope: apiResourceGroup
@@ -131,6 +134,9 @@ module apiInfrastructure 'api/main.bicep' = {
     appInsightsConnectionString: enableMonitoring ? sharedInfrastructure.outputs.connectionString : ''
     appInsightsInstrumentationKey: enableMonitoring ? sharedInfrastructure.outputs.instrumentationKey : ''
     corsAllowedOrigins: ['*'] // Update with specific origins in production
+    caseGeneratorFunctionBaseUrl: functionsInfrastructure.outputs.functionAppUrl
+    caseGeneratorStorageAccountName: functionsInfrastructure.outputs.storageAccountName
+    caseGeneratorStorageAccountId: functionsInfrastructure.outputs.storageAccountId
   }
 }
 
@@ -156,6 +162,7 @@ module functionsInfrastructure 'functions/main.bicep' = {
       'logs'
     ]
     keyVaultUri: sharedInfrastructure.outputs.keyVaultUri
+    keyVaultId: sharedInfrastructure.outputs.keyVaultId
     appInsightsConnectionString: enableMonitoring ? sharedInfrastructure.outputs.connectionString : ''
     appInsightsInstrumentationKey: enableMonitoring ? sharedInfrastructure.outputs.instrumentationKey : ''
   }

--- a/infrastructure/main.json
+++ b/infrastructure/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "5499271454964420270"
+      "version": "0.41.2.15936",
+      "templateHash": "5276162053544840087"
     }
   },
   "parameters": {
@@ -123,7 +123,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "shared-infrastructure-deployment",
       "resourceGroup": "[format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))]",
       "properties": {
@@ -160,8 +160,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "14851410719458326221"
+              "version": "0.41.2.15936",
+              "templateHash": "13968669279112914207"
             }
           },
           "parameters": {
@@ -232,7 +232,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "keyvault-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -3390,7 +3390,7 @@
             {
               "condition": "[parameters('enableMonitoring')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "loganalytics-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6386,7 +6386,7 @@
             {
               "condition": "[parameters('enableMonitoring')]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "appinsights-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -6403,7 +6403,7 @@
                   "tags": {
                     "value": "[variables('tags')]"
                   },
-                  "workspaceResourceId": "[if(parameters('enableMonitoring'), createObject('value', reference(resourceId('Microsoft.Resources/deployments', 'loganalytics-deployment'), '2022-09-01').outputs.resourceId.value), createObject('value', ''))]",
+                  "workspaceResourceId": "[if(parameters('enableMonitoring'), createObject('value', reference(resourceId('Microsoft.Resources/deployments', 'loganalytics-deployment'), '2025-04-01').outputs.resourceId.value), createObject('value', ''))]",
                   "applicationType": {
                     "value": "web"
                   },
@@ -7049,7 +7049,7 @@
             {
               "condition": "[and(and(parameters('enableSqlDatabase'), not(empty(parameters('sqlAdminLogin')))), not(empty(parameters('sqlAdminPassword'))))]",
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "sqlserver-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -13796,47 +13796,47 @@
           "outputs": {
             "keyVaultName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault-deployment'), '2022-09-01').outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault-deployment'), '2025-04-01').outputs.name.value]"
             },
             "keyVaultId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault-deployment'), '2022-09-01').outputs.resourceId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault-deployment'), '2025-04-01').outputs.resourceId.value]"
             },
             "keyVaultUri": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault-deployment'), '2022-09-01').outputs.uri.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'keyvault-deployment'), '2025-04-01').outputs.uri.value]"
             },
             "logAnalyticsWorkspaceName": {
               "type": "string",
-              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'loganalytics-deployment'), '2022-09-01').outputs.name.value, '')]"
+              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'loganalytics-deployment'), '2025-04-01').outputs.name.value, '')]"
             },
             "logAnalyticsWorkspaceId": {
               "type": "string",
-              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'loganalytics-deployment'), '2022-09-01').outputs.resourceId.value, '')]"
+              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'loganalytics-deployment'), '2025-04-01').outputs.resourceId.value, '')]"
             },
             "applicationInsightsName": {
               "type": "string",
-              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2022-09-01').outputs.name.value, '')]"
+              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2025-04-01').outputs.name.value, '')]"
             },
             "applicationInsightsId": {
               "type": "string",
-              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2022-09-01').outputs.resourceId.value, '')]"
+              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2025-04-01').outputs.resourceId.value, '')]"
             },
             "instrumentationKey": {
               "type": "string",
-              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2022-09-01').outputs.instrumentationKey.value, '')]"
+              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2025-04-01').outputs.instrumentationKey.value, '')]"
             },
             "connectionString": {
               "type": "string",
-              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2022-09-01').outputs.connectionString.value, '')]"
+              "value": "[if(parameters('enableMonitoring'), reference(resourceId('Microsoft.Resources/deployments', 'appinsights-deployment'), '2025-04-01').outputs.connectionString.value, '')]"
             },
             "sqlServerName": {
               "type": "string",
-              "value": "[if(parameters('enableSqlDatabase'), reference(resourceId('Microsoft.Resources/deployments', 'sqlserver-deployment'), '2022-09-01').outputs.name.value, '')]"
+              "value": "[if(parameters('enableSqlDatabase'), reference(resourceId('Microsoft.Resources/deployments', 'sqlserver-deployment'), '2025-04-01').outputs.name.value, '')]"
             },
             "sqlServerFqdn": {
               "type": "string",
-              "value": "[if(parameters('enableSqlDatabase'), format('{0}.{1}', reference(resourceId('Microsoft.Resources/deployments', 'sqlserver-deployment'), '2022-09-01').outputs.name.value, environment().suffixes.sqlServerHostname), '')]"
+              "value": "[if(parameters('enableSqlDatabase'), format('{0}.{1}', reference(resourceId('Microsoft.Resources/deployments', 'sqlserver-deployment'), '2025-04-01').outputs.name.value, environment().suffixes.sqlServerHostname), '')]"
             },
             "sqlDatabaseName": {
               "type": "string",
@@ -13855,7 +13855,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "api-infrastructure-deployment",
       "resourceGroup": "[format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))]",
       "properties": {
@@ -13883,19 +13883,28 @@
           "useSqlite": {
             "value": "[not(parameters('enableSqlDatabase'))]"
           },
-          "sqlConnectionString": "[if(parameters('enableSqlDatabase'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.sqlConnectionString.value), createObject('value', ''))]",
+          "sqlConnectionString": "[if(parameters('enableSqlDatabase'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.sqlConnectionString.value), createObject('value', ''))]",
           "keyVaultUri": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.keyVaultUri.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.keyVaultUri.value]"
           },
           "keyVaultId": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.keyVaultId.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.keyVaultId.value]"
           },
-          "appInsightsConnectionString": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.connectionString.value), createObject('value', ''))]",
-          "appInsightsInstrumentationKey": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.instrumentationKey.value), createObject('value', ''))]",
+          "appInsightsConnectionString": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.connectionString.value), createObject('value', ''))]",
+          "appInsightsInstrumentationKey": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.instrumentationKey.value), createObject('value', ''))]",
           "corsAllowedOrigins": {
             "value": [
               "*"
             ]
+          },
+          "caseGeneratorFunctionBaseUrl": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.functionAppUrl.value]"
+          },
+          "caseGeneratorStorageAccountName": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.storageAccountName.value]"
+          },
+          "caseGeneratorStorageAccountId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.storageAccountId.value]"
           }
         },
         "template": {
@@ -13904,8 +13913,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "16012289473249287040"
+              "version": "0.41.2.15936",
+              "templateHash": "1784837178115346124"
             }
           },
           "parameters": {
@@ -13988,6 +13997,27 @@
               "metadata": {
                 "description": "CORS allowed origins"
               }
+            },
+            "caseGeneratorFunctionBaseUrl": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Function App base URL the API proxies case-generation requests to (e.g. https://casegen-func-dev.azurewebsites.net). Wired from the functions layer output by the orchestrator."
+              }
+            },
+            "caseGeneratorStorageAccountName": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Storage Account name the API reads case bundles from via managed identity. Wired from the functions layer output by the orchestrator."
+              }
+            },
+            "caseGeneratorStorageAccountId": {
+              "type": "string",
+              "defaultValue": "",
+              "metadata": {
+                "description": "Storage Account Resource ID for the case bundles storage (used to scope the RBAC assignment cross-RG)."
+              }
             }
           },
           "variables": {
@@ -14007,7 +14037,7 @@
           "resources": [
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "api-app-service-plan-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -14572,7 +14602,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "api-app-service-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -14593,7 +14623,7 @@
                     "value": "app,linux"
                   },
                   "serverFarmResourceId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2022-09-01').outputs.resourceId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2025-04-01').outputs.resourceId.value]"
                   },
                   "httpsOnly": {
                     "value": true
@@ -14671,6 +14701,22 @@
                         {
                           "name": "IpRateLimiting__GeneralRules__0__Limit",
                           "value": "[if(equals(parameters('environment'), 'prod'), '100', '200')]"
+                        },
+                        {
+                          "name": "CaseGenerator__FunctionBaseUrl",
+                          "value": "[parameters('caseGeneratorFunctionBaseUrl')]"
+                        },
+                        {
+                          "name": "CaseGeneratorStorage__AccountName",
+                          "value": "[parameters('caseGeneratorStorageAccountName')]"
+                        },
+                        {
+                          "name": "CaseGeneratorStorage__BundlesContainer",
+                          "value": "bundles"
+                        },
+                        {
+                          "name": "CaseGeneratorStorage__CasesContainer",
+                          "value": "cases"
                         }
                       ],
                       "connectionStrings": [
@@ -20111,7 +20157,7 @@
             },
             {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "api-keyvault-rbac-deployment",
               "subscriptionId": "[split(parameters('keyVaultId'), '/')[2]]",
               "resourceGroup": "[split(parameters('keyVaultId'), '/')[4]]",
@@ -20125,7 +20171,7 @@
                     "value": "[parameters('keyVaultId')]"
                   },
                   "principalId": {
-                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.systemAssignedMIPrincipalId.value]"
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.systemAssignedMIPrincipalId.value]"
                   },
                   "principalType": {
                     "value": "ServicePrincipal"
@@ -20137,8 +20183,8 @@
                   "metadata": {
                     "_generator": {
                       "name": "bicep",
-                      "version": "0.37.4.10188",
-                      "templateHash": "14309745749085647672"
+                      "version": "0.41.2.15936",
+                      "templateHash": "18320919358290852164"
                     }
                   },
                   "parameters": {
@@ -20169,7 +20215,7 @@
                     {
                       "type": "Microsoft.Authorization/roleAssignments",
                       "apiVersion": "2022-04-01",
-                      "scope": "[format('Microsoft.KeyVault/vaults/{0}', variables('keyVaultName'))]",
+                      "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
                       "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), parameters('principalId'), 'Key Vault Secrets User')]",
                       "properties": {
                         "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
@@ -20189,44 +20235,197 @@
               "dependsOn": [
                 "[resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment')]"
               ]
+            },
+            {
+              "condition": "[not(empty(parameters('caseGeneratorStorageAccountId')))]",
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "api-storage-rbac-deployment",
+              "subscriptionId": "[split(parameters('caseGeneratorStorageAccountId'), '/')[2]]",
+              "resourceGroup": "[split(parameters('caseGeneratorStorageAccountId'), '/')[4]]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "storageAccountName": {
+                    "value": "[parameters('caseGeneratorStorageAccountName')]"
+                  },
+                  "principalId": {
+                    "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.systemAssignedMIPrincipalId.value]"
+                  },
+                  "principalType": {
+                    "value": "ServicePrincipal"
+                  },
+                  "assignBlobReader": {
+                    "value": true
+                  },
+                  "assignQueueMessageSender": {
+                    "value": true
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "4857170831897342172"
+                    }
+                  },
+                  "parameters": {
+                    "storageAccountName": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Storage Account name (in the resource group this module is deployed to)"
+                      }
+                    },
+                    "principalId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Principal ID to grant access"
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "ServicePrincipal",
+                      "metadata": {
+                        "description": "Principal Type (ServicePrincipal for managed identities)"
+                      }
+                    },
+                    "assignBlobReader": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Assign Storage Blob Data Reader role"
+                      }
+                    },
+                    "assignBlobContributor": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Assign Storage Blob Data Contributor role (broader than Reader)"
+                      }
+                    },
+                    "assignQueueMessageSender": {
+                      "type": "bool",
+                      "defaultValue": true,
+                      "metadata": {
+                        "description": "Assign Storage Queue Data Message Sender role (send-only)"
+                      }
+                    },
+                    "assignQueueContributor": {
+                      "type": "bool",
+                      "defaultValue": false,
+                      "metadata": {
+                        "description": "Assign Storage Queue Data Contributor role (queue management + messages)"
+                      }
+                    }
+                  },
+                  "variables": {
+                    "roleIds": {
+                      "blobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+                      "blobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+                      "queueDataMessageSender": "c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
+                      "queueDataContributor": "974c5e8b-45b9-4653-ba55-5f855dd0fb88"
+                    }
+                  },
+                  "resources": [
+                    {
+                      "condition": "[parameters('assignBlobReader')]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                      "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').blobDataReader)]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').blobDataReader)]",
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "[parameters('principalType')]"
+                      }
+                    },
+                    {
+                      "condition": "[parameters('assignBlobContributor')]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                      "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').blobDataContributor)]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').blobDataContributor)]",
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "[parameters('principalType')]"
+                      }
+                    },
+                    {
+                      "condition": "[parameters('assignQueueMessageSender')]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                      "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').queueDataMessageSender)]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').queueDataMessageSender)]",
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "[parameters('principalType')]"
+                      }
+                    },
+                    {
+                      "condition": "[parameters('assignQueueContributor')]",
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                      "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').queueDataContributor)]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').queueDataContributor)]",
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "[parameters('principalType')]"
+                      }
+                    }
+                  ]
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment')]"
+              ]
             }
           ],
           "outputs": {
             "appServicePlanId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2022-09-01').outputs.resourceId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2025-04-01').outputs.resourceId.value]"
             },
             "appServicePlanName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2022-09-01').outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2025-04-01').outputs.name.value]"
             },
             "apiAppServiceName": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.name.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.name.value]"
             },
             "apiAppServiceId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.resourceId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.resourceId.value]"
             },
             "apiAppServiceUrl": {
               "type": "string",
-              "value": "[format('https://{0}', reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.defaultHostname.value)]"
+              "value": "[format('https://{0}', reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.defaultHostname.value)]"
             },
             "apiAppServicePrincipalId": {
               "type": "string",
-              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.systemAssignedMIPrincipalId.value]"
+              "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.systemAssignedMIPrincipalId.value]"
             }
           }
         }
       },
       "dependsOn": [
         "[subscriptionResourceId('Microsoft.Resources/resourceGroups', format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment')))]",
+        "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment')]",
         "[extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment')]"
       ]
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "functions-infrastructure-deployment",
       "resourceGroup": "[format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))]",
       "properties": {
@@ -20260,10 +20459,13 @@
             ]
           },
           "keyVaultUri": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.keyVaultUri.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.keyVaultUri.value]"
           },
-          "appInsightsConnectionString": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.connectionString.value), createObject('value', ''))]",
-          "appInsightsInstrumentationKey": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.instrumentationKey.value), createObject('value', ''))]"
+          "keyVaultId": {
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.keyVaultId.value]"
+          },
+          "appInsightsConnectionString": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.connectionString.value), createObject('value', ''))]",
+          "appInsightsInstrumentationKey": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.instrumentationKey.value), createObject('value', ''))]"
         },
         "template": {
           "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
@@ -20272,8 +20474,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "3935228819977192629"
+              "version": "0.41.2.15936",
+              "templateHash": "3775805189380899413"
             }
           },
           "parameters": {
@@ -20332,6 +20534,12 @@
                 "description": "Key Vault URI from shared infrastructure"
               }
             },
+            "keyVaultId": {
+              "type": "string",
+              "metadata": {
+                "description": "Key Vault Resource ID from shared infrastructure (used to grant the Function App MI access to secrets)"
+              }
+            },
             "appInsightsConnectionString": {
               "type": "string",
               "defaultValue": "",
@@ -20371,9 +20579,25 @@
                 "storageAccount"
               ]
             },
+            "queueService": {
+              "type": "Microsoft.Storage/storageAccounts/queueServices",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}', variables('storageAccountName'), 'default')]",
+              "dependsOn": [
+                "storageAccount"
+              ]
+            },
+            "forensicRequestsQueue": {
+              "type": "Microsoft.Storage/storageAccounts/queueServices/queues",
+              "apiVersion": "2023-05-01",
+              "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', 'forensic-requests')]",
+              "dependsOn": [
+                "queueService"
+              ]
+            },
             "storageAccount": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "functions-storage-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -26090,7 +26314,7 @@
             },
             "appServicePlan": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "functions-app-service-plan-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -26651,7 +26875,7 @@
             },
             "functionApp": {
               "type": "Microsoft.Resources/deployments",
-              "apiVersion": "2022-09-01",
+              "apiVersion": "2025-04-01",
               "name": "functions-app-deployment",
               "properties": {
                 "expressionEvaluationOptions": {
@@ -26741,6 +26965,10 @@
                           "value": "[format('DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1};EndpointSuffix={2}', variables('storageAccountName'), listKeys('existingStorageAccount', '2023-05-01').keys[0].value, environment().suffixes.storage)]"
                         },
                         {
+                          "name": "CaseGeneratorStorage__AccountName",
+                          "value": "[variables('storageAccountName')]"
+                        },
+                        {
                           "name": "CaseGeneratorStorage__CasesContainer",
                           "value": "cases"
                         },
@@ -26757,16 +26985,24 @@
                           "value": "CaseGeneratorHub"
                         },
                         {
-                          "name": "AzureOpenAI__Endpoint",
-                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-openai-endpoint/)', parameters('keyVaultUri'))]"
+                          "name": "LLM__UseAzureFoundry",
+                          "value": "true"
                         },
                         {
-                          "name": "AzureOpenAI__ApiKey",
-                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-openai-api-key/)', parameters('keyVaultUri'))]"
+                          "name": "AzureFoundry__Endpoint",
+                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-foundry-endpoint/)', parameters('keyVaultUri'))]"
                         },
                         {
-                          "name": "AzureOpenAI__DeploymentName",
-                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-openai-deployment-name/)', parameters('keyVaultUri'))]"
+                          "name": "AzureFoundry__ApiKey",
+                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-foundry-api-key/)', parameters('keyVaultUri'))]"
+                        },
+                        {
+                          "name": "AzureFoundry__ModelName",
+                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-foundry-model-name/)', parameters('keyVaultUri'))]"
+                        },
+                        {
+                          "name": "AzureFoundry__ImageDeploymentName",
+                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/azure-foundry-image-deployment-name/)', parameters('keyVaultUri'))]"
                         }
                       ]
                     }
@@ -32201,6 +32437,87 @@
                 "appServicePlan",
                 "storageAccount"
               ]
+            },
+            "functionsKeyVaultRoleAssignment": {
+              "type": "Microsoft.Resources/deployments",
+              "apiVersion": "2025-04-01",
+              "name": "functions-keyvault-rbac-deployment",
+              "subscriptionId": "[split(parameters('keyVaultId'), '/')[2]]",
+              "resourceGroup": "[split(parameters('keyVaultId'), '/')[4]]",
+              "properties": {
+                "expressionEvaluationOptions": {
+                  "scope": "inner"
+                },
+                "mode": "Incremental",
+                "parameters": {
+                  "keyVaultId": {
+                    "value": "[parameters('keyVaultId')]"
+                  },
+                  "principalId": {
+                    "value": "[reference('functionApp').outputs.systemAssignedMIPrincipalId.value]"
+                  },
+                  "principalType": {
+                    "value": "ServicePrincipal"
+                  }
+                },
+                "template": {
+                  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+                  "contentVersion": "1.0.0.0",
+                  "metadata": {
+                    "_generator": {
+                      "name": "bicep",
+                      "version": "0.41.2.15936",
+                      "templateHash": "18320919358290852164"
+                    }
+                  },
+                  "parameters": {
+                    "keyVaultId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Key Vault Resource ID"
+                      }
+                    },
+                    "principalId": {
+                      "type": "string",
+                      "metadata": {
+                        "description": "Principal ID to grant access"
+                      }
+                    },
+                    "principalType": {
+                      "type": "string",
+                      "defaultValue": "ServicePrincipal",
+                      "metadata": {
+                        "description": "Principal Type"
+                      }
+                    }
+                  },
+                  "variables": {
+                    "keyVaultName": "[last(split(parameters('keyVaultId'), '/'))]"
+                  },
+                  "resources": [
+                    {
+                      "type": "Microsoft.Authorization/roleAssignments",
+                      "apiVersion": "2022-04-01",
+                      "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+                      "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), parameters('principalId'), 'Key Vault Secrets User')]",
+                      "properties": {
+                        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
+                        "principalId": "[parameters('principalId')]",
+                        "principalType": "[parameters('principalType')]"
+                      }
+                    }
+                  ],
+                  "outputs": {
+                    "roleAssignmentId": {
+                      "type": "string",
+                      "value": "[extensionResourceId(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), 'Microsoft.Authorization/roleAssignments', guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), parameters('principalId'), 'Key Vault Secrets User'))]"
+                    }
+                  }
+                }
+              },
+              "dependsOn": [
+                "functionApp"
+              ]
             }
           },
           "outputs": {
@@ -32246,7 +32563,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "frontend-infrastructure-deployment",
       "resourceGroup": "[format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))]",
       "properties": {
@@ -32268,7 +32585,7 @@
             }
           },
           "backendApiUrl": {
-            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2022-09-01').outputs.apiAppServiceUrl.value]"
+            "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2025-04-01').outputs.apiAppServiceUrl.value]"
           },
           "repositoryUrl": {
             "value": "[parameters('repositoryUrl')]"
@@ -32283,8 +32600,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "12529005113727641418"
+              "version": "0.41.2.15936",
+              "templateHash": "11629848759132541252"
             }
           },
           "parameters": {
@@ -32436,68 +32753,68 @@
     },
     "keyVaultName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.keyVaultName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.keyVaultName.value]"
     },
     "keyVaultUri": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.keyVaultUri.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.keyVaultUri.value]"
     },
     "applicationInsightsName": {
       "type": "string",
-      "value": "[if(parameters('enableMonitoring'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.applicationInsightsName.value, '')]"
+      "value": "[if(parameters('enableMonitoring'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.applicationInsightsName.value, '')]"
     },
     "logAnalyticsWorkspaceName": {
       "type": "string",
-      "value": "[if(parameters('enableMonitoring'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.logAnalyticsWorkspaceName.value, '')]"
+      "value": "[if(parameters('enableMonitoring'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.logAnalyticsWorkspaceName.value, '')]"
     },
     "sqlServerName": {
       "type": "string",
-      "value": "[if(parameters('enableSqlDatabase'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.sqlServerName.value, '')]"
+      "value": "[if(parameters('enableSqlDatabase'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.sqlServerName.value, '')]"
     },
     "sqlServerFqdn": {
       "type": "string",
-      "value": "[if(parameters('enableSqlDatabase'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.sqlServerFqdn.value, '')]"
+      "value": "[if(parameters('enableSqlDatabase'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.sqlServerFqdn.value, '')]"
     },
     "sqlDatabaseName": {
       "type": "string",
-      "value": "[if(parameters('enableSqlDatabase'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2022-09-01').outputs.sqlDatabaseName.value, '')]"
+      "value": "[if(parameters('enableSqlDatabase'), reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.sqlDatabaseName.value, '')]"
     },
     "apiAppServiceName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2022-09-01').outputs.apiAppServiceName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2025-04-01').outputs.apiAppServiceName.value]"
     },
     "apiAppServiceUrl": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2022-09-01').outputs.apiAppServiceUrl.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2025-04-01').outputs.apiAppServiceUrl.value]"
     },
     "functionAppName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2022-09-01').outputs.functionAppName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.functionAppName.value]"
     },
     "functionAppUrl": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2022-09-01').outputs.functionAppUrl.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.functionAppUrl.value]"
     },
     "functionsStorageAccountName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2022-09-01').outputs.storageAccountName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.storageAccountName.value]"
     },
     "staticWebAppName": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'frontend-infrastructure-deployment'), '2022-09-01').outputs.staticWebAppName.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'frontend-infrastructure-deployment'), '2025-04-01').outputs.staticWebAppName.value]"
     },
     "staticWebAppUrl": {
       "type": "string",
-      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'frontend-infrastructure-deployment'), '2022-09-01').outputs.staticWebAppUrl.value]"
+      "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'frontend-infrastructure-deployment'), '2025-04-01').outputs.staticWebAppUrl.value]"
     },
     "deploymentSummary": {
       "type": "object",
       "value": {
         "environment": "[parameters('environment')]",
         "location": "[parameters('location')]",
-        "frontendUrl": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'frontend-infrastructure-deployment'), '2022-09-01').outputs.staticWebAppUrl.value]",
-        "apiUrl": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2022-09-01').outputs.apiAppServiceUrl.value]",
-        "functionsUrl": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2022-09-01').outputs.functionAppUrl.value]",
+        "frontendUrl": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-web-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'frontend-infrastructure-deployment'), '2025-04-01').outputs.staticWebAppUrl.value]",
+        "apiUrl": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-api-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'api-infrastructure-deployment'), '2025-04-01').outputs.apiAppServiceUrl.value]",
+        "functionsUrl": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.functionAppUrl.value]",
         "sqlEnabled": "[parameters('enableSqlDatabase')]",
         "monitoringEnabled": "[parameters('enableMonitoring')]"
       }


### PR DESCRIPTION
## What

Closes TASK 4 in acklog/BACKLOG.md. Three things in one PR (all interdependent):

1. **Backend migrates to Managed Identity for Case Generator Storage.** Required because the storage account `stcadevcabtlmvw4g` has `allowSharedKeyAccess: false` enforced by Azure Policy `Azure_Security_Baseline` — the existing `CaseGeneratorStorage__ConnectionString` is dead. Dashboard returns empty `cases:[]` until this lands.

2. **Bicep IaC catches up with the manual `az` config drift applied during TASK 3.** Without this, anyone re-provisioning from scratch gets a broken environment.

3. **`ResolveCasesBasePath` fallback fix** so the FA doesn't need `CaseGenV2__CasesBasePath=/tmp` set as a per-environment workaround.

## Why

* Dashboard is currently broken in Azure dev: the connection-string-only backend can't read blobs from a storage account that refuses shared key.
* Function App generated case `case_20260515_193838` lives in `bundles/` but the Web App can't see it — confirmed via direct blob read.
* Bicep doesn't reflect the actual working config of dev (`AzureFoundry__*` vs broken `AzureOpenAI__*` refs, missing KV RBAC, no `CaseGenerator__FunctionBaseUrl` on the Web App, etc).

## How

### Backend (4 files migrated to MI via shared factory)

* New `CaseGeneratorStorageFactory` mirrors the pattern that already exists in `CaseGen.Functions`: prefers `CaseGeneratorStorage:AccountName` + `DefaultAzureCredential`, falls back to connection string for local dev (Azurite).
* `TokenCredential` registered as singleton in DI so token caching is reused across scoped requests.
* `CaseV2StorageService`, `AssetsController`, `EmailsController`, `ForensicQueueService` all go through the factory.
* `ListCasesAsync` no longer calls `CreateIfNotExistsAsync` — the API runs with least-privilege `Storage Blob Data Reader` and the bundles container is pre-created by Bicep.
* `ForensicQueueService.CreateIfNotExists` is now best-effort (log warning instead of throw) so the singleton can start under `Storage Queue Data Message Sender`; the queue is pre-provisioned by Bicep.
* Integration test factory explicitly blanks `CaseGeneratorStorage:AccountName` so tests stick to the Azurite/connection-string path.

### Functions

* `CaseV2GeneratorService.ResolveCasesBasePath` fallback: `Path.GetTempPath()/casegen` instead of `AppContext.BaseDirectory/cases`. Works on Linux Function App (where `/home/site/wwwroot` is read-only) and on Windows + macOS local dev. After this lands, `CaseGenV2__CasesBasePath=/tmp` can be removed from the FA.

### Bicep

* `functions/main.bicep`: drop `AzureOpenAI__*`; add `LLM__UseAzureFoundry` + `AzureFoundry__*` (KV refs to existing `azure-foundry-*` secrets); add `CaseGeneratorStorage__AccountName`; pre-create the `forensic-requests` queue; grant FA MI `Key Vault Secrets User` on the shared KV via the existing `keyvault-rbac.bicep` module.
* `api/main.bicep`: new params + app settings `CaseGenerator__FunctionBaseUrl`, `CaseGeneratorStorage__AccountName/BundlesContainer/CasesContainer`; new `storage-rbac.bicep` module assigns `Storage Blob Data Reader` + `Storage Queue Data Message Sender` to the API MI cross-RG.
* `main.bicep` (orchestrator): wire `functionsInfrastructure` outputs into `apiInfrastructure` params (creates implicit dependency — api deploys after functions).

### Docs

* `infrastructure/README.md` updated.
* `backlog/BACKLOG.md` adds the manual follow-up steps required in Azure dev until `azd provision` is re-run, plus new **TASK 5** for the remaining `AzureWebJobsStorage` MI migration on the FA (needs plan change to Flex Consumption/EP1 — out of scope here).

## Validation

* ✅ `dotnet build CaseZero-Alternative.sln -c Release` — 0 errors, 0 warnings
* ✅ 60 backend unit tests pass
* ✅ 34 backend integration tests pass (+ 2 skipped as before)
* ✅ 7 functions unit tests pass
* ✅ `az bicep build infrastructure/main.bicep` — clean (only pre-existing BCP318 warnings in shared/main.bicep, unrelated)

## Post-merge manual steps (Azure dev)

CI deploys CODE only. Bicep changes don't get applied automatically. After this PR merges, run the commands documented under **TASK 4** in `backlog/BACKLOG.md` (RBAC + appsettings update) to make the Azure dev environment match the new code.

## Risk

* The code keeps the connection-string fallback path, so deploying the code while the new `CaseGeneratorStorage__AccountName` setting hasn't been applied yet is safe (still reads via the broken connection string, dashboard stays empty just like today — no regression).
* Once `AccountName` is set on the Web App, the code prefers MI. If the RBAC propagation lags (5-10 min), there's a small window of 403s. To minimize: apply role assignment FIRST, wait, then set `AccountName`, then delete the connection string.