### PR TITLE
fix(task-6): CORS configuravel + remover wildcard do App Service

### DIFF
--- a/backend/CaseZeroApi/Program.cs
+++ b/backend/CaseZeroApi/Program.cs
@@ -114,11 +114,26 @@ builder.Services.AddAuthentication(options =>
 });
 
 // Configure CORS
+//
+// Allowed origins are sourced from configuration (Cors:AllowedOrigins) so the
+// list can grow per-environment without touching code. Defaults cover local
+// dev (Vite on http and https). Production / dev Azure pass the SWA origin
+// via app settings (Cors__AllowedOrigins__0=https://...).
+//
+// IMPORTANT: this middleware MUST be the only CORS authority for the app.
+// Do NOT also configure CORS at the App Service level (siteConfig.cors) —
+// App Service-level CORS doesn't support `credentials: include`, which
+// SignalR requires for /hubs/forensics negotiation.
+var corsAllowedOrigins = builder.Configuration
+    .GetSection("Cors:AllowedOrigins")
+    .Get<string[]>()
+    ?? new[] { "http://localhost:5173", "https://localhost:5173" };
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
     {
-        policy.WithOrigins("http://localhost:5173") // Vite dev server
+        policy.WithOrigins(corsAllowedOrigins)
               .AllowAnyMethod()
               .AllowAnyHeader()
               .AllowCredentials();

--- a/infrastructure/api/main.bicep
+++ b/infrastructure/api/main.bicep
@@ -44,8 +44,11 @@ param appInsightsConnectionString string = ''
 @description('Application Insights Instrumentation Key from shared infrastructure')
 param appInsightsInstrumentationKey string = ''
 
-@description('CORS allowed origins')
-param corsAllowedOrigins array = ['*']
+@description('CORS allowed origins surfaced into app settings as Cors__AllowedOrigins__N. Defaults to local dev only; the orchestrator should pass the SWA origin for deployed environments. App Service-level CORS is intentionally left empty so the .NET middleware is the single source of truth (App Service CORS does not support credentials, which SignalR requires).')
+param corsAllowedOrigins array = [
+  'http://localhost:5173'
+  'https://localhost:5173'
+]
 
 @description('Function App base URL the API proxies case-generation requests to (e.g. https://casegen-func-dev.azurewebsites.net). Wired from the functions layer output by the orchestrator.')
 param caseGeneratorFunctionBaseUrl string = ''
@@ -112,11 +115,15 @@ module apiAppService 'br/public:avm/res/web/site:0.14.0' = {
       scmMinTlsVersion: '1.2'
       http20Enabled: true
       healthCheckPath: '/health'
+      // CORS is owned by the .NET middleware (Cors:AllowedOrigins from app
+      // settings). App Service-level CORS is intentionally empty: it does not
+      // support `credentials: include`, which SignalR requires, and any value
+      // here overrides whatever the middleware emits.
       cors: {
-        allowedOrigins: corsAllowedOrigins
+        allowedOrigins: []
         supportCredentials: false
       }
-      appSettings: [
+      appSettings: concat([
         {
           name: 'ASPNETCORE_ENVIRONMENT'
           value: environment == 'prod' ? 'Production' : (environment == 'staging' ? 'Staging' : 'Development')
@@ -185,7 +192,10 @@ module apiAppService 'br/public:avm/res/web/site:0.14.0' = {
           name: 'CaseGeneratorStorage__CasesContainer'
           value: 'cases'
         }
-      ]
+      ], map(range(0, length(corsAllowedOrigins)), i => {
+        name: 'Cors__AllowedOrigins__${i}'
+        value: corsAllowedOrigins[i]
+      }))
       // Connection Strings
       connectionStrings: [
         {

--- a/infrastructure/api/main.json
+++ b/infrastructure/api/main.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.37.4.10188",
-      "templateHash": "16012289473249287040"
+      "version": "0.41.2.15936",
+      "templateHash": "10079933765412903654"
     }
   },
   "parameters": {
@@ -83,10 +83,32 @@
     "corsAllowedOrigins": {
       "type": "array",
       "defaultValue": [
-        "*"
+        "http://localhost:5173",
+        "https://localhost:5173"
       ],
       "metadata": {
-        "description": "CORS allowed origins"
+        "description": "CORS allowed origins surfaced into app settings as Cors__AllowedOrigins__N. Defaults to local dev only; the orchestrator should pass the SWA origin for deployed environments. App Service-level CORS is intentionally left empty so the .NET middleware is the single source of truth (App Service CORS does not support credentials, which SignalR requires)."
+      }
+    },
+    "caseGeneratorFunctionBaseUrl": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Function App base URL the API proxies case-generation requests to (e.g. https://casegen-func-dev.azurewebsites.net). Wired from the functions layer output by the orchestrator."
+      }
+    },
+    "caseGeneratorStorageAccountName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Storage Account name the API reads case bundles from via managed identity. Wired from the functions layer output by the orchestrator."
+      }
+    },
+    "caseGeneratorStorageAccountId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Storage Account Resource ID for the case bundles storage (used to scope the RBAC assignment cross-RG)."
       }
     }
   },
@@ -107,7 +129,7 @@
   "resources": [
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "api-app-service-plan-deployment",
       "properties": {
         "expressionEvaluationOptions": {
@@ -672,7 +694,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "api-app-service-deployment",
       "properties": {
         "expressionEvaluationOptions": {
@@ -693,7 +715,7 @@
             "value": "app,linux"
           },
           "serverFarmResourceId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2022-09-01').outputs.resourceId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2025-04-01').outputs.resourceId.value]"
           },
           "httpsOnly": {
             "value": true
@@ -716,63 +738,10 @@
               "http20Enabled": true,
               "healthCheckPath": "/health",
               "cors": {
-                "allowedOrigins": "[parameters('corsAllowedOrigins')]",
+                "allowedOrigins": [],
                 "supportCredentials": false
               },
-              "appSettings": [
-                {
-                  "name": "ASPNETCORE_ENVIRONMENT",
-                  "value": "[if(equals(parameters('environment'), 'prod'), 'Production', if(equals(parameters('environment'), 'staging'), 'Staging', 'Development'))]"
-                },
-                {
-                  "name": "WEBSITE_RUN_FROM_PACKAGE",
-                  "value": "1"
-                },
-                {
-                  "name": "JwtSettings__SecretKey",
-                  "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/jwt-signing-key/)', parameters('keyVaultUri'))]"
-                },
-                {
-                  "name": "JwtSettings__Issuer",
-                  "value": "CaseZeroApi"
-                },
-                {
-                  "name": "JwtSettings__Audience",
-                  "value": "CaseZeroClient"
-                },
-                {
-                  "name": "JwtSettings__ExpirationInMinutes",
-                  "value": "[if(equals(parameters('environment'), 'prod'), '60', '1440')]"
-                },
-                {
-                  "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                  "value": "[parameters('appInsightsInstrumentationKey')]"
-                },
-                {
-                  "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                  "value": "[parameters('appInsightsConnectionString')]"
-                },
-                {
-                  "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
-                  "value": "~3"
-                },
-                {
-                  "name": "IpRateLimiting__EnableEndpointRateLimiting",
-                  "value": "true"
-                },
-                {
-                  "name": "IpRateLimiting__GeneralRules__0__Endpoint",
-                  "value": "*"
-                },
-                {
-                  "name": "IpRateLimiting__GeneralRules__0__Period",
-                  "value": "1m"
-                },
-                {
-                  "name": "IpRateLimiting__GeneralRules__0__Limit",
-                  "value": "[if(equals(parameters('environment'), 'prod'), '100', '200')]"
-                }
-              ],
+              "appSettings": "[concat(createArray(createObject('name', 'ASPNETCORE_ENVIRONMENT', 'value', if(equals(parameters('environment'), 'prod'), 'Production', if(equals(parameters('environment'), 'staging'), 'Staging', 'Development'))), createObject('name', 'WEBSITE_RUN_FROM_PACKAGE', 'value', '1'), createObject('name', 'JwtSettings__SecretKey', 'value', format('@Microsoft.KeyVault(SecretUri={0}secrets/jwt-signing-key/)', parameters('keyVaultUri'))), createObject('name', 'JwtSettings__Issuer', 'value', 'CaseZeroApi'), createObject('name', 'JwtSettings__Audience', 'value', 'CaseZeroClient'), createObject('name', 'JwtSettings__ExpirationInMinutes', 'value', if(equals(parameters('environment'), 'prod'), '60', '1440')), createObject('name', 'APPINSIGHTS_INSTRUMENTATIONKEY', 'value', parameters('appInsightsInstrumentationKey')), createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', parameters('appInsightsConnectionString')), createObject('name', 'ApplicationInsightsAgent_EXTENSION_VERSION', 'value', '~3'), createObject('name', 'IpRateLimiting__EnableEndpointRateLimiting', 'value', 'true'), createObject('name', 'IpRateLimiting__GeneralRules__0__Endpoint', 'value', '*'), createObject('name', 'IpRateLimiting__GeneralRules__0__Period', 'value', '1m'), createObject('name', 'IpRateLimiting__GeneralRules__0__Limit', 'value', if(equals(parameters('environment'), 'prod'), '100', '200')), createObject('name', 'CaseGenerator__FunctionBaseUrl', 'value', parameters('caseGeneratorFunctionBaseUrl')), createObject('name', 'CaseGeneratorStorage__AccountName', 'value', parameters('caseGeneratorStorageAccountName')), createObject('name', 'CaseGeneratorStorage__BundlesContainer', 'value', 'bundles'), createObject('name', 'CaseGeneratorStorage__CasesContainer', 'value', 'cases')), map(range(0, length(parameters('corsAllowedOrigins'))), lambda('i', createObject('name', format('Cors__AllowedOrigins__{0}', lambdaVariables('i')), 'value', parameters('corsAllowedOrigins')[lambdaVariables('i')]))))]",
               "connectionStrings": [
                 {
                   "name": "DefaultConnection",
@@ -6211,7 +6180,7 @@
     },
     {
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2025-04-01",
       "name": "api-keyvault-rbac-deployment",
       "subscriptionId": "[split(parameters('keyVaultId'), '/')[2]]",
       "resourceGroup": "[split(parameters('keyVaultId'), '/')[4]]",
@@ -6225,7 +6194,7 @@
             "value": "[parameters('keyVaultId')]"
           },
           "principalId": {
-            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.systemAssignedMIPrincipalId.value]"
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.systemAssignedMIPrincipalId.value]"
           },
           "principalType": {
             "value": "ServicePrincipal"
@@ -6237,8 +6206,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.37.4.10188",
-              "templateHash": "14309745749085647672"
+              "version": "0.41.2.15936",
+              "templateHash": "18320919358290852164"
             }
           },
           "parameters": {
@@ -6269,7 +6238,7 @@
             {
               "type": "Microsoft.Authorization/roleAssignments",
               "apiVersion": "2022-04-01",
-              "scope": "[format('Microsoft.KeyVault/vaults/{0}', variables('keyVaultName'))]",
+              "scope": "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
               "name": "[guid(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), parameters('principalId'), 'Key Vault Secrets User')]",
               "properties": {
                 "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '4633458b-17de-408a-b874-0445c86b69e6')]",
@@ -6289,32 +6258,184 @@
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment')]"
       ]
+    },
+    {
+      "condition": "[not(empty(parameters('caseGeneratorStorageAccountId')))]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2025-04-01",
+      "name": "api-storage-rbac-deployment",
+      "subscriptionId": "[split(parameters('caseGeneratorStorageAccountId'), '/')[2]]",
+      "resourceGroup": "[split(parameters('caseGeneratorStorageAccountId'), '/')[4]]",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "storageAccountName": {
+            "value": "[parameters('caseGeneratorStorageAccountName')]"
+          },
+          "principalId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.systemAssignedMIPrincipalId.value]"
+          },
+          "principalType": {
+            "value": "ServicePrincipal"
+          },
+          "assignBlobReader": {
+            "value": true
+          },
+          "assignQueueMessageSender": {
+            "value": true
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.41.2.15936",
+              "templateHash": "4857170831897342172"
+            }
+          },
+          "parameters": {
+            "storageAccountName": {
+              "type": "string",
+              "metadata": {
+                "description": "Storage Account name (in the resource group this module is deployed to)"
+              }
+            },
+            "principalId": {
+              "type": "string",
+              "metadata": {
+                "description": "Principal ID to grant access"
+              }
+            },
+            "principalType": {
+              "type": "string",
+              "defaultValue": "ServicePrincipal",
+              "metadata": {
+                "description": "Principal Type (ServicePrincipal for managed identities)"
+              }
+            },
+            "assignBlobReader": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Assign Storage Blob Data Reader role"
+              }
+            },
+            "assignBlobContributor": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Assign Storage Blob Data Contributor role (broader than Reader)"
+              }
+            },
+            "assignQueueMessageSender": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Assign Storage Queue Data Message Sender role (send-only)"
+              }
+            },
+            "assignQueueContributor": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Assign Storage Queue Data Contributor role (queue management + messages)"
+              }
+            }
+          },
+          "variables": {
+            "roleIds": {
+              "blobDataReader": "2a2b9908-6ea1-4ae2-8e65-a410df84e7d1",
+              "blobDataContributor": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+              "queueDataMessageSender": "c6a89b2d-59bc-44d0-9896-0f6e12d7b80a",
+              "queueDataContributor": "974c5e8b-45b9-4653-ba55-5f855dd0fb88"
+            }
+          },
+          "resources": [
+            {
+              "condition": "[parameters('assignBlobReader')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').blobDataReader)]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').blobDataReader)]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "[parameters('principalType')]"
+              }
+            },
+            {
+              "condition": "[parameters('assignBlobContributor')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').blobDataContributor)]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').blobDataContributor)]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "[parameters('principalType')]"
+              }
+            },
+            {
+              "condition": "[parameters('assignQueueMessageSender')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').queueDataMessageSender)]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').queueDataMessageSender)]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "[parameters('principalType')]"
+              }
+            },
+            {
+              "condition": "[parameters('assignQueueContributor')]",
+              "type": "Microsoft.Authorization/roleAssignments",
+              "apiVersion": "2022-04-01",
+              "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+              "name": "[guid(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), parameters('principalId'), variables('roleIds').queueDataContributor)]",
+              "properties": {
+                "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleIds').queueDataContributor)]",
+                "principalId": "[parameters('principalId')]",
+                "principalType": "[parameters('principalType')]"
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment')]"
+      ]
     }
   ],
   "outputs": {
     "appServicePlanId": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2022-09-01').outputs.resourceId.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2025-04-01').outputs.resourceId.value]"
     },
     "appServicePlanName": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2022-09-01').outputs.name.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-plan-deployment'), '2025-04-01').outputs.name.value]"
     },
     "apiAppServiceName": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.name.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.name.value]"
     },
     "apiAppServiceId": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.resourceId.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.resourceId.value]"
     },
     "apiAppServiceUrl": {
       "type": "string",
-      "value": "[format('https://{0}', reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.defaultHostname.value)]"
+      "value": "[format('https://{0}', reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.defaultHostname.value)]"
     },
     "apiAppServicePrincipalId": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2022-09-01').outputs.systemAssignedMIPrincipalId.value]"
+      "value": "[reference(resourceId('Microsoft.Resources/deployments', 'api-app-service-deployment'), '2025-04-01').outputs.systemAssignedMIPrincipalId.value]"
     }
   }
 }

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -133,7 +133,14 @@ module apiInfrastructure 'api/main.bicep' = {
     keyVaultId: sharedInfrastructure.outputs.keyVaultId
     appInsightsConnectionString: enableMonitoring ? sharedInfrastructure.outputs.connectionString : ''
     appInsightsInstrumentationKey: enableMonitoring ? sharedInfrastructure.outputs.instrumentationKey : ''
-    corsAllowedOrigins: ['*'] // Update with specific origins in production
+    // corsAllowedOrigins intentionally not set here — the api/main.bicep default
+    // covers localhost dev. The deployed frontend origin (Static Web App auto
+    // hostname) is not known at this point in the deployment (api deploys
+    // before frontend to avoid a circular dependency on backendApiUrl), so it
+    // must be added post-provision via:
+    //   az webapp config appsettings set -n <api> -g <rg> \
+    //       --settings Cors__AllowedOrigins__2=https://<swa-hostname>
+    // Prod: pass corsAllowedOrigins explicitly with the custom domain.
     caseGeneratorFunctionBaseUrl: functionsInfrastructure.outputs.functionAppUrl
     caseGeneratorStorageAccountName: functionsInfrastructure.outputs.storageAccountName
     caseGeneratorStorageAccountId: functionsInfrastructure.outputs.storageAccountId

--- a/infrastructure/main.json
+++ b/infrastructure/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "5276162053544840087"
+      "templateHash": "5409758438042462884"
     }
   },
   "parameters": {
@@ -13892,11 +13892,6 @@
           },
           "appInsightsConnectionString": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.connectionString.value), createObject('value', ''))]",
           "appInsightsInstrumentationKey": "[if(parameters('enableMonitoring'), createObject('value', reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-shared-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'shared-infrastructure-deployment'), '2025-04-01').outputs.instrumentationKey.value), createObject('value', ''))]",
-          "corsAllowedOrigins": {
-            "value": [
-              "*"
-            ]
-          },
           "caseGeneratorFunctionBaseUrl": {
             "value": "[reference(extensionResourceId(format('/subscriptions/{0}/resourceGroups/{1}', subscription().subscriptionId, format('{0}-func-{1}-rg', parameters('namePrefix'), parameters('environment'))), 'Microsoft.Resources/deployments', 'functions-infrastructure-deployment'), '2025-04-01').outputs.functionAppUrl.value]"
           },
@@ -13914,7 +13909,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.41.2.15936",
-              "templateHash": "1784837178115346124"
+              "templateHash": "10079933765412903654"
             }
           },
           "parameters": {
@@ -13992,10 +13987,11 @@
             "corsAllowedOrigins": {
               "type": "array",
               "defaultValue": [
-                "*"
+                "http://localhost:5173",
+                "https://localhost:5173"
               ],
               "metadata": {
-                "description": "CORS allowed origins"
+                "description": "CORS allowed origins surfaced into app settings as Cors__AllowedOrigins__N. Defaults to local dev only; the orchestrator should pass the SWA origin for deployed environments. App Service-level CORS is intentionally left empty so the .NET middleware is the single source of truth (App Service CORS does not support credentials, which SignalR requires)."
               }
             },
             "caseGeneratorFunctionBaseUrl": {
@@ -14646,79 +14642,10 @@
                       "http20Enabled": true,
                       "healthCheckPath": "/health",
                       "cors": {
-                        "allowedOrigins": "[parameters('corsAllowedOrigins')]",
+                        "allowedOrigins": [],
                         "supportCredentials": false
                       },
-                      "appSettings": [
-                        {
-                          "name": "ASPNETCORE_ENVIRONMENT",
-                          "value": "[if(equals(parameters('environment'), 'prod'), 'Production', if(equals(parameters('environment'), 'staging'), 'Staging', 'Development'))]"
-                        },
-                        {
-                          "name": "WEBSITE_RUN_FROM_PACKAGE",
-                          "value": "1"
-                        },
-                        {
-                          "name": "JwtSettings__SecretKey",
-                          "value": "[format('@Microsoft.KeyVault(SecretUri={0}secrets/jwt-signing-key/)', parameters('keyVaultUri'))]"
-                        },
-                        {
-                          "name": "JwtSettings__Issuer",
-                          "value": "CaseZeroApi"
-                        },
-                        {
-                          "name": "JwtSettings__Audience",
-                          "value": "CaseZeroClient"
-                        },
-                        {
-                          "name": "JwtSettings__ExpirationInMinutes",
-                          "value": "[if(equals(parameters('environment'), 'prod'), '60', '1440')]"
-                        },
-                        {
-                          "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-                          "value": "[parameters('appInsightsInstrumentationKey')]"
-                        },
-                        {
-                          "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
-                          "value": "[parameters('appInsightsConnectionString')]"
-                        },
-                        {
-                          "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
-                          "value": "~3"
-                        },
-                        {
-                          "name": "IpRateLimiting__EnableEndpointRateLimiting",
-                          "value": "true"
-                        },
-                        {
-                          "name": "IpRateLimiting__GeneralRules__0__Endpoint",
-                          "value": "*"
-                        },
-                        {
-                          "name": "IpRateLimiting__GeneralRules__0__Period",
-                          "value": "1m"
-                        },
-                        {
-                          "name": "IpRateLimiting__GeneralRules__0__Limit",
-                          "value": "[if(equals(parameters('environment'), 'prod'), '100', '200')]"
-                        },
-                        {
-                          "name": "CaseGenerator__FunctionBaseUrl",
-                          "value": "[parameters('caseGeneratorFunctionBaseUrl')]"
-                        },
-                        {
-                          "name": "CaseGeneratorStorage__AccountName",
-                          "value": "[parameters('caseGeneratorStorageAccountName')]"
-                        },
-                        {
-                          "name": "CaseGeneratorStorage__BundlesContainer",
-                          "value": "bundles"
-                        },
-                        {
-                          "name": "CaseGeneratorStorage__CasesContainer",
-                          "value": "cases"
-                        }
-                      ],
+                      "appSettings": "[concat(createArray(createObject('name', 'ASPNETCORE_ENVIRONMENT', 'value', if(equals(parameters('environment'), 'prod'), 'Production', if(equals(parameters('environment'), 'staging'), 'Staging', 'Development'))), createObject('name', 'WEBSITE_RUN_FROM_PACKAGE', 'value', '1'), createObject('name', 'JwtSettings__SecretKey', 'value', format('@Microsoft.KeyVault(SecretUri={0}secrets/jwt-signing-key/)', parameters('keyVaultUri'))), createObject('name', 'JwtSettings__Issuer', 'value', 'CaseZeroApi'), createObject('name', 'JwtSettings__Audience', 'value', 'CaseZeroClient'), createObject('name', 'JwtSettings__ExpirationInMinutes', 'value', if(equals(parameters('environment'), 'prod'), '60', '1440')), createObject('name', 'APPINSIGHTS_INSTRUMENTATIONKEY', 'value', parameters('appInsightsInstrumentationKey')), createObject('name', 'APPLICATIONINSIGHTS_CONNECTION_STRING', 'value', parameters('appInsightsConnectionString')), createObject('name', 'ApplicationInsightsAgent_EXTENSION_VERSION', 'value', '~3'), createObject('name', 'IpRateLimiting__EnableEndpointRateLimiting', 'value', 'true'), createObject('name', 'IpRateLimiting__GeneralRules__0__Endpoint', 'value', '*'), createObject('name', 'IpRateLimiting__GeneralRules__0__Period', 'value', '1m'), createObject('name', 'IpRateLimiting__GeneralRules__0__Limit', 'value', if(equals(parameters('environment'), 'prod'), '100', '200')), createObject('name', 'CaseGenerator__FunctionBaseUrl', 'value', parameters('caseGeneratorFunctionBaseUrl')), createObject('name', 'CaseGeneratorStorage__AccountName', 'value', parameters('caseGeneratorStorageAccountName')), createObject('name', 'CaseGeneratorStorage__BundlesContainer', 'value', 'bundles'), createObject('name', 'CaseGeneratorStorage__CasesContainer', 'value', 'cases')), map(range(0, length(parameters('corsAllowedOrigins'))), lambda('i', createObject('name', format('Cors__AllowedOrigins__{0}', lambdaVariables('i')), 'value', parameters('corsAllowedOrigins')[lambdaVariables('i')]))))]",
                       "connectionStrings": [
                         {
                           "name": "DefaultConnection",


### PR DESCRIPTION
Closes TASK 6 in `backlog/BACKLOG.md`.

## Sintoma

No SWA de dev, depois de logar e abrir um caso:

```
Access to fetch at 'https://casezero-api-dev.azurewebsites.net/hubs/forensics/negotiate?negotiateVersion=1'
from origin 'https://gentle-ground-03dca4110.3.azurestaticapps.net' has been blocked by CORS policy:
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*'
when the request's credentials mode is 'include'.
```

## Causa raiz

Dois bugs combinados:

1. `infrastructure/api/main.bicep` definia `siteConfig.cors.allowedOrigins=['*']` no App Service. Esse CORS **de nível infraestrutura** (Kestrel/IIS handler do App Service) responde **antes** do middleware do .NET e **não suporta credenciais** — qualquer fetch com `credentials: include` (cookies, JWT em header com auth, SignalR negotiate) é rejeitado pelo browser, porque `*` é proibido com credenciais por especificação.

2. `Program.cs` só permitia `http://localhost:5173` hard-coded — mesmo que o App Service-level CORS fosse arrumado, o middleware do .NET não conheceria o SWA.

## Mudanças

### Código

* `backend/CaseZeroApi/Program.cs`: lê origens permitidas de `Cors:AllowedOrigins` (array). Default sem config: `http://localhost:5173` + `https://localhost:5173`. Comentário no código deixa explícito que o App Service CORS deve ficar vazio.

### Bicep

* `infrastructure/api/main.bicep`:
  * Param `corsAllowedOrigins` default agora é o par localhost (em vez de `['*']`).
  * `siteConfig.cors.allowedOrigins` agora **sempre** `[]` — o middleware do .NET é a única autoridade.
  * Cada item de `corsAllowedOrigins` vira app setting `Cors__AllowedOrigins__N` para o .NET ler via `IConfiguration`.
* `infrastructure/main.bicep`: removida a linha `corsAllowedOrigins: ['*']`. O default do módulo cobre localhost. A origem do SWA é desconhecida em tempo de provision (api deploya antes do frontend para evitar dep circular com `backendApiUrl`) — precisa ser adicionada pós-deploy via `az` (comando inline no comentário).

## Manual em Azure dev (rodar depois do merge)

```bash
# 1. Limpar o CORS de nivel App Service (entra em conflito com middleware)
az webapp cors remove -n casezero-api-dev -g casezero-api-dev-rg --allowed-origins '*'

# 2. Adicionar a origem do SWA dev como Cors__AllowedOrigins__2
#    (indices 0 e 1 sao os defaults de localhost que vem do Bicep)
az webapp config appsettings set -n casezero-api-dev -g casezero-api-dev-rg \
    --settings Cors__AllowedOrigins__2=https://gentle-ground-03dca4110.3.azurestaticapps.net
```

App Service reinicia sozinho com appsettings set.

## Validação

* ✅ `dotnet build` 0 warn 0 err
* ✅ `az bicep build infrastructure/main.bicep` clean (só warnings BCP318 pré-existentes em `shared/main.bicep`)
* ✅ 60 unit tests + 34 integration tests passam (2 pre-existing skips)

## Risco

* App Service-level CORS sendo `[]` no Bicep + sem o app setting do SWA = SWA continua quebrado. **Aplicar os 2 comandos manuais acima logo após o merge / próximo deploy de código.**
* Frontend local em `localhost:5173` continua funcionando sem mudança.