### PR TITLE
fix(emails): TASK 8 — frontend sends real emailId on open (no more /emails/undefined/open)

### DIFF
--- a/backend/CaseZeroApi/Controllers/EmailsController.cs
+++ b/backend/CaseZeroApi/Controllers/EmailsController.cs
@@ -317,7 +317,7 @@ namespace CaseZeroApi.Controllers
                 {
                     emailId = email.Id,
                     from = email.From,
-                    to = email.To,
+                    to = string.Join("; ", email.To ?? new List<string>()),
                     subject = email.Subject,
                     sentAt = email.SentAt,
                     priority = email.Priority,

--- a/frontend/src/components/apps/EmailApp.tsx
+++ b/frontend/src/components/apps/EmailApp.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
-import type { EmailListDTO, EmailDTO } from '../../services/api'
+import type { EmailDTO } from '../../services/api'
 import { emailsApi } from '../../services/api'
+import type { Email } from '../../types/caseV2'
 
 const EmailAppContainer = styled.div`
   height: 100%;
@@ -182,7 +183,7 @@ const LoadingMessage = styled.div`
 `
 
 interface EmailAppProps {
-  emails?: EmailListDTO[]
+  emails?: Email[]
   caseId?: string
   onRefetchAssets?: () => void
 }
@@ -190,19 +191,51 @@ interface EmailAppProps {
 const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId, onRefetchAssets }) => {
   const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null)
   const [openedEmail, setOpenedEmail] = useState<EmailDTO | null>(null)
+  const [readIds, setReadIds] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(false)
   const [downloadingAttachment, setDownloadingAttachment] = useState<string | null>(null)
 
-  const handleEmailClick = async (emailId: string) => {
+  // Reset transient UI state when switching cases and hydrate read state
+  // from the server so reopening the window preserves prior reads.
+  useEffect(() => {
+    setSelectedEmailId(null)
+    setOpenedEmail(null)
+    setReadIds(new Set())
+
     if (!caseId) return
 
+    let cancelled = false
+    emailsApi.getEmails(caseId)
+      .then(list => {
+        if (cancelled) return
+        const read = new Set<string>()
+        for (const e of list) {
+          if (e.isRead && e.emailId) read.add(e.emailId)
+        }
+        setReadIds(read)
+      })
+      .catch(err => console.warn('Failed to hydrate email read state:', err))
+
+    return () => { cancelled = true }
+  }, [caseId])
+
+  const handleEmailClick = async (emailId: string) => {
+    if (!caseId || !emailId) return
+
     setSelectedEmailId(emailId)
+    setOpenedEmail(null)
     setLoading(true)
 
     try {
       // Task 49: POST /open then GET full email
       const fullEmail = await emailsApi.openEmail(caseId, emailId)
       setOpenedEmail(fullEmail)
+      setReadIds(prev => {
+        if (prev.has(emailId)) return prev
+        const next = new Set(prev)
+        next.add(emailId)
+        return next
+      })
     } catch (error) {
       console.error('Failed to open email:', error)
     } finally {
@@ -260,23 +293,27 @@ const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId, onRefetchAsset
                 No emails available
               </div>
             ) : (
-              emails.map(email => (
-                <EmailItem
-                  key={email.emailId}
-                  $isRead={email.isRead}
-                  $isSelected={selectedEmailId === email.emailId}
-                  onClick={() => handleEmailClick(email.emailId)}
-                >
-                  <EmailHeader>
-                    <EmailFrom $isRead={email.isRead}>{email.from}</EmailFrom>
-                    <EmailTime>{formatTimestamp(email.sentAt)}</EmailTime>
-                  </EmailHeader>
-                  <EmailSubject $isRead={email.isRead}>
-                    {email.hasAttachments && '📎 '}
-                    {email.subject}
-                  </EmailSubject>
-                </EmailItem>
-              ))
+              emails.map(email => {
+                const isRead = readIds.has(email.id)
+                const hasAttachments = !!email.attachments && email.attachments.length > 0
+                return (
+                  <EmailItem
+                    key={email.id}
+                    $isRead={isRead}
+                    $isSelected={selectedEmailId === email.id}
+                    onClick={() => handleEmailClick(email.id)}
+                  >
+                    <EmailHeader>
+                      <EmailFrom $isRead={isRead}>{email.from}</EmailFrom>
+                      <EmailTime>{formatTimestamp(email.sentAt)}</EmailTime>
+                    </EmailHeader>
+                    <EmailSubject $isRead={isRead}>
+                      {hasAttachments && '📎 '}
+                      {email.subject}
+                    </EmailSubject>
+                  </EmailItem>
+                )
+              })
             )}
           </EmailList>
         </LeftPanel>
@@ -293,10 +330,12 @@ const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId, onRefetchAsset
                   <MetadataLabel>From:</MetadataLabel>
                   <MetadataValue>{openedEmail.from}</MetadataValue>
                 </MetadataRow>
-                <MetadataRow>
-                  <MetadataLabel>To:</MetadataLabel>
-                  <MetadataValue>{openedEmail.to}</MetadataValue>
-                </MetadataRow>
+                  <MetadataRow>
+                    <MetadataLabel>To:</MetadataLabel>
+                    <MetadataValue>
+                      {Array.isArray(openedEmail.to) ? openedEmail.to.join('; ') : openedEmail.to}
+                    </MetadataValue>
+                  </MetadataRow>
                 <MetadataRow>
                   <MetadataLabel>Date:</MetadataLabel>
                   <MetadataValue>{new Date(openedEmail.sentAt).toLocaleString()}</MetadataValue>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -662,7 +662,7 @@ export const assetsApi = {
 export interface EmailDTO {
   emailId: string
   from: string
-  to: string
+  to: string | string[]
   subject: string
   content: string
   sentAt: string


### PR DESCRIPTION
Closes the front-end side of backlog **TASK 8** (frontend was sending `undefined` as `emailId`).

## Root cause

`Desktop.tsx` injects `emails={useEmails()}` which is `state.visibleEmails: Email[]` from `CaseEngine` — the raw **v2 case.json** shape with field `id`.

`EmailApp.tsx` was typed as `emails?: EmailListDTO[]` (the backend list-endpoint DTO with field `emailId`). React doesn't type-check props injected via `openWindow(...)`, so the mismatch slipped through and at runtime `email.emailId` was always `undefined`.

Result in the browser:
```
POST /api/cases/case_20260515_193838/emails/undefined/open → 400
```

For comparison, `FileViewer` works accidentally because it reads `asset.id`, which exists on both v2 `Asset` and `AssetDTO`.

## Fix

- **`EmailApp.tsx`**
  - Accepts raw v2 `Email[]` (mirrors how `FileViewer` treats assets). Renders with `email.id` for key/onClick and derives `hasAttachments` from `email.attachments?.length`.
  - Tracks `isRead` client-side via a `readIds` `Set<string>` that's hydrated on mount / `caseId` change from `emailsApi.getEmails(caseId)` so reopening the Email window preserves previously read state.
  - Resets `selectedEmailId` / `openedEmail` / `readIds` on case switch.
  - Clears `openedEmail` before each open so stale content doesn't show during loading or after a failed open.
  - Guards against an empty `emailId`.

- **`services/api.ts`**
  - `EmailDTO.to` widened to `string | string[]` to match what the backend actually returns from the detail endpoint.

- **`EmailsController.cs` `GetEmailDetails`**
  - Collapses `email.To` (`List<string>`) into `string.Join(""; "", ...)` so the JSON shape is consistent with the list endpoint and renders cleanly.

## Validation

- `npm run build` — green (tsc + vite).
- `dotnet build CaseZeroApi.csproj` — green.
- Will smoke-test on Azure dev after the CI deploys this branch (the user can verify by clicking an email on case `case_20260515_193838`).

## Why it worked ""locally""

It didn't — the bug exists in the same code. Either nobody clicked an email in the local run, or the user opened a different EmailApp code path. The fix is environment-independent.

## Notes

- SignalR `case.entity.revealed` flow into `CaseEngine` is preserved — we still consume `useEmails()` for the live list.
- Backend `CaseEmailDto` (list-endpoint DTO) is unchanged; the list call is now also used for read-state hydration.

Reviewed by the rubber-duck agent before commit.