### PR TITLE
feat(emails): unlock email attachments into FileViewer on download + session-aware visibility

### DIFF
--- a/frontend/src/components/apps/EmailApp.tsx
+++ b/frontend/src/components/apps/EmailApp.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import type { EmailDTO } from '../../services/api'
 import { emailsApi } from '../../services/api'
 import type { Email } from '../../types/caseV2'
+import { useCase, useAssets } from '../../contexts/CaseContext'
 
 const EmailAppContainer = styled.div`
   height: 100%;
@@ -185,15 +186,26 @@ const LoadingMessage = styled.div`
 interface EmailAppProps {
   emails?: Email[]
   caseId?: string
-  onRefetchAssets?: () => void
 }
 
-const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId, onRefetchAssets }) => {
+const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId }) => {
+  const { refreshCase } = useCase()
+  const visibleAssets = useAssets()
   const [selectedEmailId, setSelectedEmailId] = useState<string | null>(null)
   const [openedEmail, setOpenedEmail] = useState<EmailDTO | null>(null)
   const [readIds, setReadIds] = useState<Set<string>>(new Set())
   const [loading, setLoading] = useState(false)
   const [downloadingAttachment, setDownloadingAttachment] = useState<string | null>(null)
+
+  // Index visible assets so we can mark attachments that are already
+  // available in the FileViewer and show their real display name.
+  const assetIndex = useMemo(() => {
+    const map = new Map<string, { name: string }>()
+    for (const a of visibleAssets) {
+      map.set(a.id, { name: a.title || a.id })
+    }
+    return map
+  }, [visibleAssets])
 
   // Reset transient UI state when switching cases and hydrate read state
   // from the server so reopening the window preserves prior reads.
@@ -250,12 +262,17 @@ const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId, onRefetchAsset
 
     try {
       // Task 50: POST /emails/{emailId}/attachments/{assetId}/download
+      // Backend records the download, unlocks the asset for this session
+      // (CaseSessionVisibleAssets), and streams the blob — we only care about
+      // the unlock side-effect here so the asset shows up in FileViewer.
       await emailsApi.downloadAttachment(caseId, openedEmail.emailId, assetId)
-      
-      // Refetch assets to update FileViewer
-      if (onRefetchAssets) {
-        onRefetchAssets()
-      }
+
+      // Refetch the sanitized case so the freshly unlocked attachment asset
+      // (which may have been 'hidden' in case.json) shows up in visibleAssets
+      // and therefore in the FileViewer. applyReveal can't be used here
+      // because hidden assets aren't present in state.case.assets until the
+      // sanitizer sees them in CaseSessionVisibleAssets.
+      await refreshCase()
 
       console.log(`✅ Attachment ${assetId} downloaded successfully`)
     } catch (error) {
@@ -350,17 +367,35 @@ const EmailApp: React.FC<EmailAppProps> = ({ emails = [], caseId, onRefetchAsset
                     📎 Attachments ({openedEmail.attachments.length})
                   </h5>
                   <AttachmentsList>
-                    {openedEmail.attachments.map((assetId, index) => (
-                      <AttachmentItem key={assetId}>
-                        <AttachmentName>Attachment_{index + 1} (ID: {assetId})</AttachmentName>
-                        <DownloadButton
-                          onClick={() => handleDownloadAttachment(assetId)}
-                          disabled={downloadingAttachment === assetId}
-                        >
-                          {downloadingAttachment === assetId ? 'Downloading...' : 'Download'}
-                        </DownloadButton>
-                      </AttachmentItem>
-                    ))}
+                    {openedEmail.attachments.map((assetId, index) => {
+                      const known = assetIndex.get(assetId)
+                      const isDownloaded = !!known
+                      const displayName = known?.name || `Attachment_${index + 1}`
+                      return (
+                        <AttachmentItem key={assetId}>
+                          <AttachmentName>
+                            {isDownloaded && '✓ '}
+                            {displayName}
+                            {!isDownloaded && (
+                              <span style={{ color: 'rgba(255, 255, 255, 0.4)', fontSize: 11, marginLeft: 6 }}>
+                                (ID: {assetId})
+                              </span>
+                            )}
+                          </AttachmentName>
+                          <DownloadButton
+                            onClick={() => handleDownloadAttachment(assetId)}
+                            disabled={downloadingAttachment === assetId || isDownloaded}
+                            title={isDownloaded ? 'Already available in Files' : 'Download to Files'}
+                          >
+                            {downloadingAttachment === assetId
+                              ? 'Downloading...'
+                              : isDownloaded
+                                ? 'In Files'
+                                : 'Download'}
+                          </DownloadButton>
+                        </AttachmentItem>
+                      )
+                    })}
                   </AttachmentsList>
                 </AttachmentsSection>
               )}

--- a/frontend/src/contexts/CaseContext.tsx
+++ b/frontend/src/contexts/CaseContext.tsx
@@ -53,6 +53,12 @@ interface CaseContextValue {
   viewSuspect: (suspectId: string) => Promise<void>
   submitCase: (payload: SubmitCaseRequest) => Promise<SubmitCaseResult>
   postGameTime: (min: number) => Promise<void>
+  // Refetch the sanitized case from the server (e.g., after a download
+  // unlocks an attachment asset) without resetting submission/notifications.
+  refreshCase: () => Promise<void>
+  // Locally reveal an entity in CaseEngine state. Useful for SignalR-driven
+  // reveals where the revealed entity is already present in state.case.
+  applyReveal: (entityType: 'email' | 'asset' | 'suspect', entityId: string) => void
   // Back-compat: legacy TimeSync uses this. Accepts a Date.
   updateGameTime: (newTime: Date) => void
 }
@@ -165,6 +171,11 @@ export const CaseProvider: React.FC<{ children: ReactNode; caseId?: string }> = 
     viewSuspect: (id) => engine.viewSuspect(id),
     submitCase: (payload) => engine.submitCase(payload),
     postGameTime: (min) => engine.postGameTime(min),
+    refreshCase: async () => {
+      if (!activeCaseId) return
+      await engine.refreshCase(activeCaseId)
+    },
+    applyReveal: (entityType, id) => engine.applyReveal(entityType, id),
     updateGameTime,
   }
 

--- a/frontend/src/engine/CaseEngine.ts
+++ b/frontend/src/engine/CaseEngine.ts
@@ -75,14 +75,14 @@ export class CaseEngine {
   async loadCase(caseId: string): Promise<void> {
     try {
       const caseData = await this.apiClient.getCase(caseId)
-      const visibleAssets = caseData.assets.filter(a => a.visibility === 'initial')
-      const visibleEmails = caseData.emails.filter(e => e.visibility === 'initial')
-      const visibleSuspects = caseData.suspects.filter(s => s.visibility === 'initial')
+      // Trust the sanitized response from the backend: it already includes
+      // entities that are 'initial' OR session-unlocked (CaseSessionVisible*).
+      // Re-filtering by static visibility here would discard session unlocks.
       this.setState({
         case: caseData,
-        visibleAssets,
-        visibleEmails,
-        visibleSuspects,
+        visibleAssets: caseData.assets,
+        visibleEmails: caseData.emails,
+        visibleSuspects: caseData.suspects,
         submission: {
           attemptsUsed: 0,
           maxAttempts: caseData.solution.maxAttempts
@@ -91,6 +91,23 @@ export class CaseEngine {
     } catch (err) {
       console.error('CaseEngine.loadCase failed:', err)
       throw err
+    }
+  }
+
+  // Refetch the sanitized case to pick up session-visibility changes
+  // (e.g., after a user downloads an email attachment, which unlocks an
+  // asset server-side). Preserves submission/notifications state.
+  async refreshCase(caseId: string): Promise<void> {
+    try {
+      const caseData = await this.apiClient.getCase(caseId)
+      this.setState({
+        case: caseData,
+        visibleAssets: caseData.assets,
+        visibleEmails: caseData.emails,
+        visibleSuspects: caseData.suspects,
+      })
+    } catch (err) {
+      console.error('CaseEngine.refreshCase failed:', err)
     }
   }
 


### PR DESCRIPTION
Closes the attachment side of backlog **TASK 8**. Builds on top of #137 (the email-id fix that's already merged).

## What users see now

- Clicking **Download** on an email attachment makes the file appear in **FileViewer** for the rest of the case session **and** on subsequent reloads.
- Already-downloaded attachments are clearly marked with `✓ <real asset title>` and the button shows ""In Files"" (disabled) instead of ""Download"" again.

## Root cause

Two coupled bugs:

1. **Frontend ignored server-side session visibility.** `CaseEngine.loadCase` was re-filtering `caseData.assets` by the *static* `visibility === 'initial'` field, even though the backend sanitizer (`CaseV2SanitizerService.SanitizeForUserAsync`) already returns `initial OR session-visible`. The client filter overrode the server's session-aware logic, so any gated-reveal (asset unlocked via `CaseSessionVisibleAssets`) was invisible to the UI — both within a session and across reloads.
2. **No refresh after attachment download.** `EmailApp` had an `onRefetchAssets` prop, but `Desktop` never passed it. The post-download server-side unlock was correct, but the UI had no signal to re-fetch.

(An earlier attempt to use `CaseEngine.applyReveal('asset', id)` was a dead end — confirmed by code review: hidden assets are stripped from `state.case.assets` by the sanitizer until they appear in `CaseSessionVisibleAssets`, so the in-memory `find()` returned undefined and `applyReveal` no-op'd.)

## Changes

### Engine / context
- **`CaseEngine.loadCase`** drops the redundant client-side `.filter(visibility === 'initial')` and trusts the sanitized response directly. This single change also fixes cross-session persistence for *every* gated reveal (assets, emails, suspects), not just email attachments.
- **`CaseEngine.refreshCase(caseId)`** (new): re-fetch sanitized case and update visibleAssets/Emails/Suspects + case, preserving `submission` and `notifications` state.
- **`CaseContext`** exposes `refreshCase()` (and `applyReveal` — kept for future SignalR reveal events that operate on entities already in `state.case`).

### EmailApp
- Removed the unused `onRefetchAssets` prop.
- Consumes `useAssets()` and `useCase().refreshCase` directly.
- After a successful `emailsApi.downloadAttachment(...)`, calls `refreshCase()` so the freshly unlocked attachment appears in FileViewer.
- Attachment list cross-references `assetId` with the visible-assets set:
  - **Downloaded**: `✓ <real asset title>`, button = ""In Files"" (disabled, tooltip explains).
  - **Not yet downloaded**: `Attachment_<n>` + `(ID: …)`, button = ""Download"".

## Validation

- `npm run build` (tsc + vite) — green.
- `npm test --run` — 25/25 passing.
- Manual smoke once CI deploys: open an email with attachments, click Download on each, expect the asset to appear in FileViewer with the correct name; close & reopen the case, expect previously downloaded attachments to remain visible.

## Notes

- This PR touches the *broader* CaseEngine visibility model. The change is conservative (just stops overriding the server) and aligns the frontend with what the backend has been doing all along, so it should *only fix* gated-reveal flows rather than regress any 'initial' flow.
- A real review/test of multi-tab SignalR scenarios is still future work (backend never emits `case.entity.revealed`), but the new `applyReveal` is wired through if that gets implemented.
- Rubber-duck pass caught the original `applyReveal`-only attempt before commit and steered to `refreshCase`.