### PR TITLE
fix(frontend): SPA fallback for SWA - refresh on /dashboard no longer…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ dist
 # Gatsby files
 .cache/
 public
+!frontend/public/
 
 # Storybook build outputs
 .out

--- a/frontend/public/staticwebapp.config.json
+++ b/frontend/public/staticwebapp.config.json
@@ -1,0 +1,12 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "/assets/*",
+      "/*.{css,js,png,jpg,jpeg,gif,ico,svg,webp,woff,woff2,ttf,eot,map,json,txt,xml}"
+    ]
+  },
+  "mimeTypes": {
+    ".json": "application/json"
+  }
+}


### PR DESCRIPTION
… 404s

BrowserRouter uses HTML5 routes (/dashboard, /desktop/:caseId, /case-generation). When you refresh on those URLs Azure Static Web Apps tries to serve the literal path and returns 404 because no file exists at that location.

Add staticwebapp.config.json (copied to dist/ root by Vite from frontend/public/) with navigationFallback rewriting unmatched routes to /index.html, so React Router picks them up client-side. Excludes /assets/* and the common static file extensions so PNG/CSS/JS/etc continue to 404 properly when missing instead of returning index.html.

Also un-ignore frontend/public/ (the root .gitignore had a Gatsby-style blanket 'public' rule that was hiding Vite source content).