### PR TITLE
fix(casegen): set QuestPDF Community license before first render

### DIFF
--- a/functions/CaseGen.Functions/Services/CaseV2/Rendering/DocumentResources.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Rendering/DocumentResources.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using QuestPDF;
 using QuestPDF.Drawing;
+using QuestPDF.Infrastructure;
 
 namespace CaseGen.Functions.Services.CaseV2.Rendering;
 
@@ -29,6 +31,13 @@ public static class DocumentResources
         lock (_lock)
         {
             if (_initialized) return;
+
+            // QuestPDF refuses to render until a license is declared. Setting
+            // it here means every code path that ends up rendering an
+            // EvidenceDocument is covered, including unit tests that instantiate
+            // EvidenceDocumentRenderer directly (which would otherwise miss the
+            // PdfRenderingService constructor that historically set this).
+            Settings.License = LicenseType.Community;
 
             var asm = Assembly.GetExecutingAssembly();
             foreach (var name in asm.GetManifestResourceNames())


### PR DESCRIPTION
## Hotfix — CI build broken on main

PR #141 introduced a new `EvidenceDocumentRenderer` code path that doesn't go through `PdfRenderingService`'s constructor, where `QuestPDF.Settings.License = LicenseType.Community` was historically initialised. On the Ubuntu CI runner the license check fires deterministically and the smoke tests fail; on Windows ARM64 dev hosts it happens to slip through.

Fix: move the license declaration into `DocumentResources.EnsureInitialized()` so every layout-rendering path is covered, regardless of which DI services have been instantiated first.

Verified locally: all 12 `DocumentLayoutSmokeTests` pass.
