### PR TITLE
feat(submit-case): completion checklist, forensic-analysis multiselect, sorted evidence

### DIFF
--- a/frontend/src/components/apps/SubmitCase.tsx
+++ b/frontend/src/components/apps/SubmitCase.tsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import styled from 'styled-components'
 import { useCase, useAssets, useSuspects, useSubmission } from '../../contexts/CaseContext'
 import { useLanguage } from '../../hooks/useLanguageContext'
+import { forensicRequestApi, type ForensicRequestDTO } from '../../services/api'
 import type { SubmitCaseRequest } from '../../types/caseV2'
 
 const Container = styled.div`
@@ -70,16 +71,62 @@ const Select = styled.select`
   }
 `
 
-const TextArea = styled.textarea`
-  padding: 0.6rem;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+const ProgressGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.4rem;
+`
+
+const ProgressChip = styled.div<{ $state: 'ok' | 'partial' | 'missing' }>`
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.6rem;
   border-radius: 4px;
-  color: white;
-  font-size: 13px;
-  min-height: 80px;
-  resize: vertical;
-  font-family: inherit;
+  font-size: 12px;
+  background: ${p =>
+    p.$state === 'ok'
+      ? 'rgba(46, 213, 115, 0.10)'
+      : p.$state === 'partial'
+        ? 'rgba(255, 193, 7, 0.10)'
+        : 'rgba(255, 71, 87, 0.08)'};
+  border: 1px solid ${p =>
+    p.$state === 'ok'
+      ? 'rgba(46, 213, 115, 0.4)'
+      : p.$state === 'partial'
+        ? 'rgba(255, 193, 7, 0.4)'
+        : 'rgba(255, 71, 87, 0.4)'};
+  color: ${p =>
+    p.$state === 'ok'
+      ? '#2ed573'
+      : p.$state === 'partial'
+        ? '#ffc107'
+        : '#ff6b81'};
+`
+
+const ProgressHint = styled.div<{ $state: 'ok' | 'partial' | 'missing' }>`
+  font-size: 12px;
+  color: ${p => (p.$state === 'ok' ? 'rgba(46, 213, 115, 0.9)' : 'rgba(255, 193, 7, 0.9)')};
+`
+
+const CategoryBadge = styled.span`
+  font-size: 10px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: rgba(74, 158, 255, 0.18);
+  color: #6ab8ff;
+  margin-left: 0.5rem;
+`
+
+const EmptyAnalyses = styled.div`
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.6);
+  padding: 0.6rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 4px;
 `
 
 const CheckboxGrid = styled.div`
@@ -203,6 +250,7 @@ const SubmitCase: React.FC = () => {
   const suspects = useSuspects()
   const submission = useSubmission()
 
+  const caseId = state.case?.caseId
   const questions = useMemo(() => state.case?.solution.questions ?? [], [state.case])
   const attemptsRemaining = submission.maxAttempts - submission.attemptsUsed
   const lastResult = submission.lastResult
@@ -210,12 +258,55 @@ const SubmitCase: React.FC = () => {
 
   const [suspectId, setSuspectId] = useState<string>('')
   const [evidenceIds, setEvidenceIds] = useState<string[]>([])
-  const [analysisText, setAnalysisText] = useState<string>('')
+  const [selectedAnalysisIds, setSelectedAnalysisIds] = useState<string[]>([])
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [submitting, setSubmitting] = useState(false)
 
+  const [completedAnalyses, setCompletedAnalyses] = useState<ForensicRequestDTO[] | null>(null)
+  const [loadingAnalyses, setLoadingAnalyses] = useState(false)
+
+  // Sort assets: forensic results / analysis reports first, then originals.
+  // The category names emitted by the backend vary by case template (and by language),
+  // so detect "forensic" with a loose case-insensitive match instead of a fixed list.
+  const sortedAssets = useMemo(() => {
+    const isForensic = (cat?: string) => !!cat && /forensic|peric|forense|médico|legal/i.test(cat)
+    return [...assets].sort((a, b) => {
+      const ar = isForensic(a.category) ? 0 : 1
+      const br = isForensic(b.category) ? 0 : 1
+      if (ar !== br) return ar - br
+      return a.title.localeCompare(b.title)
+    })
+  }, [assets])
+
+  useEffect(() => {
+    if (!caseId) return
+    let cancelled = false
+    setLoadingAnalyses(true)
+    forensicRequestApi
+      .getForensicRequests(caseId)
+      .then(list => {
+        if (cancelled) return
+        setCompletedAnalyses(list.filter(r => r.status === 'completed'))
+      })
+      .catch(err => {
+        if (cancelled) return
+        console.error('Failed to load forensic requests:', err)
+        setCompletedAnalyses([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingAnalyses(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [caseId])
+
   const toggleEvidence = (id: string) => {
     setEvidenceIds(prev => (prev.includes(id) ? prev.filter(e => e !== id) : [...prev, id]))
+  }
+
+  const toggleAnalysis = (id: string) => {
+    setSelectedAnalysisIds(prev => (prev.includes(id) ? prev.filter(e => e !== id) : [...prev, id]))
   }
 
   const handleAnswerChange = (questionId: string, optionId: string) => {
@@ -229,10 +320,7 @@ const SubmitCase: React.FC = () => {
     const payload: SubmitCaseRequest = {
       suspectId,
       evidenceIds,
-      analysisIds: analysisText
-        .split(/[\n,]/)
-        .map(s => s.trim())
-        .filter(Boolean),
+      analysisIds: selectedAnalysisIds,
       answers: questions.map(q => ({
         questionId: q.id,
         optionId: answers[q.id] || '',
@@ -253,12 +341,63 @@ const SubmitCase: React.FC = () => {
     ? t('submitCaseAttemptsExhausted')
     : t('submitCaseAttemptsRemaining').replace('{n}', String(attemptsRemaining))
 
+  // Progress state (advisory only — submit stays enabled as long as suspect is set,
+  // because the backend permits partial submissions and just gives 0 on missing buckets).
+  const answeredCount = questions.filter(q => !!answers[q.id]).length
+  const suspectState: 'ok' | 'missing' = suspectId ? 'ok' : 'missing'
+  const evidenceState: 'ok' | 'partial' = evidenceIds.length > 0 ? 'ok' : 'partial'
+  const analysisState: 'ok' | 'partial' = selectedAnalysisIds.length > 0 ? 'ok' : 'partial'
+  const questionsState: 'ok' | 'partial' | 'missing' =
+    questions.length === 0
+      ? 'ok'
+      : answeredCount === questions.length
+        ? 'ok'
+        : answeredCount === 0
+          ? 'missing'
+          : 'partial'
+
+  const allReady =
+    suspectState === 'ok' &&
+    evidenceState === 'ok' &&
+    analysisState === 'ok' &&
+    questionsState === 'ok'
+
   return (
     <Container>
       <Header>
         <HeaderTitle>⚖️ {t('submitCaseTitle')}</HeaderTitle>
         <HeaderSubtitle>{attemptsLabel}</HeaderSubtitle>
       </Header>
+
+      <Section>
+        <SectionTitle>{t('submitCaseProgressTitle')}</SectionTitle>
+        <ProgressGrid>
+          <ProgressChip $state={suspectState}>
+            {suspectState === 'ok' ? '✓' : '○'} {t('submitCaseProgressSuspect')}
+          </ProgressChip>
+          <ProgressChip $state={evidenceState}>
+            {evidenceState === 'ok' ? '✓' : '○'}{' '}
+            {t('submitCaseProgressEvidence').replace('{n}', String(evidenceIds.length))}
+          </ProgressChip>
+          <ProgressChip $state={analysisState}>
+            {analysisState === 'ok' ? '✓' : '○'}{' '}
+            {t('submitCaseProgressAnalysis').replace('{n}', String(selectedAnalysisIds.length))}
+          </ProgressChip>
+          <ProgressChip $state={questionsState}>
+            {questionsState === 'ok' ? '✓' : '○'}{' '}
+            {t('submitCaseProgressQuestions')
+              .replace('{a}', String(answeredCount))
+              .replace('{b}', String(questions.length))}
+          </ProgressChip>
+        </ProgressGrid>
+        {allReady ? (
+          <ProgressHint $state="ok">✓ {t('submitCaseProgressReady')}</ProgressHint>
+        ) : suspectState === 'missing' ? (
+          <ProgressHint $state="missing">{t('submitCaseProgressMissingSuspect')}</ProgressHint>
+        ) : questionsState !== 'ok' && questions.length > 0 ? (
+          <ProgressHint $state="partial">{t('submitCaseProgressMissingQuestions')}</ProgressHint>
+        ) : null}
+      </Section>
 
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         <Section>
@@ -280,7 +419,7 @@ const SubmitCase: React.FC = () => {
         <Section>
           <SectionTitle>{t('submitCaseEvidenceLabel')}</SectionTitle>
           <CheckboxGrid>
-            {assets.map(asset => (
+            {sortedAssets.map(asset => (
               <CheckboxItem key={asset.id}>
                 <input
                   type="checkbox"
@@ -288,7 +427,10 @@ const SubmitCase: React.FC = () => {
                   onChange={() => toggleEvidence(asset.id)}
                   disabled={isExhausted}
                 />
-                <span>{asset.title}</span>
+                <span>
+                  {asset.title}
+                  {asset.category && <CategoryBadge>{asset.category}</CategoryBadge>}
+                </span>
               </CheckboxItem>
             ))}
           </CheckboxGrid>
@@ -296,12 +438,31 @@ const SubmitCase: React.FC = () => {
 
         <Section>
           <SectionTitle>{t('submitCaseAnalysisLabel')}</SectionTitle>
-          <TextArea
-            placeholder="asset.id:AnalysisType (one per line or comma-separated)"
-            value={analysisText}
-            onChange={e => setAnalysisText(e.target.value)}
-            disabled={isExhausted}
-          />
+          {loadingAnalyses ? (
+            <EmptyAnalyses>{t('submitCaseAnalysisLoading')}</EmptyAnalyses>
+          ) : completedAnalyses && completedAnalyses.length > 0 ? (
+            <CheckboxGrid>
+              {completedAnalyses.map(req => {
+                const analysisId = `${req.inputAssetId}:${req.analysisType}`
+                const label = req.inputAssetName
+                  ? `${req.inputAssetName} — ${req.analysisType}`
+                  : analysisId
+                return (
+                  <CheckboxItem key={analysisId}>
+                    <input
+                      type="checkbox"
+                      checked={selectedAnalysisIds.includes(analysisId)}
+                      onChange={() => toggleAnalysis(analysisId)}
+                      disabled={isExhausted}
+                    />
+                    <span>{label}</span>
+                  </CheckboxItem>
+                )
+              })}
+            </CheckboxGrid>
+          ) : (
+            <EmptyAnalyses>{t('submitCaseAnalysisEmpty')}</EmptyAnalyses>
+          )}
         </Section>
 
         {questions.length > 0 && (

--- a/frontend/src/locales/en-US.ts
+++ b/frontend/src/locales/en-US.ts
@@ -433,6 +433,8 @@ export const enUS: Translations = {
   submitCaseSuspectLabel: 'Primary Suspect',
   submitCaseEvidenceLabel: 'Evidence',
   submitCaseAnalysisLabel: 'Forensic Analyses',
+  submitCaseAnalysisLoading: 'Loading completed analyses…',
+  submitCaseAnalysisEmpty: 'No completed forensic analyses yet. Open the Forensics Lab to request one.',
   submitCaseQuestionsHeader: 'Investigation Questions',
   submitCaseSubmitButton: 'Submit Case',
   submitCaseAttemptsRemaining: '{n} attempts remaining',
@@ -445,6 +447,14 @@ export const enUS: Translations = {
   submitCaseBreakdownAnalysis: 'Analysis',
   submitCaseBreakdownQuestions: 'Questions',
   submitCaseExplanationHeader: 'Case Explanation',
+  submitCaseProgressTitle: 'Submission Checklist',
+  submitCaseProgressSuspect: 'Suspect',
+  submitCaseProgressEvidence: 'Evidence ({n})',
+  submitCaseProgressAnalysis: 'Analyses ({n})',
+  submitCaseProgressQuestions: 'Questions ({a}/{b})',
+  submitCaseProgressReady: 'Ready to submit',
+  submitCaseProgressMissingSuspect: 'Select a primary suspect',
+  submitCaseProgressMissingQuestions: 'Some questions are unanswered — you can still submit, but those points will be lost',
 
   // Dashboard V2
   dashboardRequiredRank: 'Required Rank',

--- a/frontend/src/locales/es-ES.ts
+++ b/frontend/src/locales/es-ES.ts
@@ -433,6 +433,8 @@ export const esES: Translations = {
   submitCaseSuspectLabel: 'Sospechoso Principal',
   submitCaseEvidenceLabel: 'Evidencias',
   submitCaseAnalysisLabel: 'Análisis Forenses',
+  submitCaseAnalysisLoading: 'Cargando análisis completados…',
+  submitCaseAnalysisEmpty: 'Aún no hay análisis forenses completados. Abre el Laboratorio Forense para solicitar uno.',
   submitCaseQuestionsHeader: 'Preguntas de Investigación',
   submitCaseSubmitButton: 'Enviar Caso',
   submitCaseAttemptsRemaining: '{n} intentos restantes',
@@ -445,6 +447,14 @@ export const esES: Translations = {
   submitCaseBreakdownAnalysis: 'Análisis',
   submitCaseBreakdownQuestions: 'Preguntas',
   submitCaseExplanationHeader: 'Explicación del Caso',
+  submitCaseProgressTitle: 'Lista de Envío',
+  submitCaseProgressSuspect: 'Sospechoso',
+  submitCaseProgressEvidence: 'Evidencias ({n})',
+  submitCaseProgressAnalysis: 'Análisis ({n})',
+  submitCaseProgressQuestions: 'Preguntas ({a}/{b})',
+  submitCaseProgressReady: 'Listo para enviar',
+  submitCaseProgressMissingSuspect: 'Selecciona un sospechoso principal',
+  submitCaseProgressMissingQuestions: 'Algunas preguntas siguen sin respuesta — aún puedes enviar, pero perderás esos puntos',
 
   // Dashboard V2
   dashboardRequiredRank: 'Rango Requerido',

--- a/frontend/src/locales/fr-FR.ts
+++ b/frontend/src/locales/fr-FR.ts
@@ -433,6 +433,8 @@ export const frFR: Translations = {
   submitCaseSuspectLabel: 'Suspect principal',
   submitCaseEvidenceLabel: 'Preuves',
   submitCaseAnalysisLabel: 'Analyses médico-légales',
+  submitCaseAnalysisLoading: 'Chargement des analyses terminées…',
+  submitCaseAnalysisEmpty: 'Aucune analyse médico-légale terminée pour le moment. Ouvrez le Laboratoire pour en demander une.',
   submitCaseQuestionsHeader: "Questions d'enquête",
   submitCaseSubmitButton: 'Soumettre le dossier',
   submitCaseAttemptsRemaining: '{n} tentatives restantes',
@@ -445,6 +447,14 @@ export const frFR: Translations = {
   submitCaseBreakdownAnalysis: 'Analyse',
   submitCaseBreakdownQuestions: 'Questions',
   submitCaseExplanationHeader: 'Explication du dossier',
+  submitCaseProgressTitle: 'Liste de contrôle',
+  submitCaseProgressSuspect: 'Suspect',
+  submitCaseProgressEvidence: 'Preuves ({n})',
+  submitCaseProgressAnalysis: 'Analyses ({n})',
+  submitCaseProgressQuestions: 'Questions ({a}/{b})',
+  submitCaseProgressReady: 'Prêt à soumettre',
+  submitCaseProgressMissingSuspect: 'Sélectionnez un suspect principal',
+  submitCaseProgressMissingQuestions: 'Certaines questions restent sans réponse — vous pouvez soumettre, mais ces points seront perdus',
 
   // Dashboard V2
   dashboardRequiredRank: 'Rang requis',

--- a/frontend/src/locales/pt-BR.ts
+++ b/frontend/src/locales/pt-BR.ts
@@ -433,6 +433,8 @@ export const ptBR: Translations = {
   submitCaseSuspectLabel: 'Suspeito Principal',
   submitCaseEvidenceLabel: 'Evidências',
   submitCaseAnalysisLabel: 'Análises Forenses',
+  submitCaseAnalysisLoading: 'Carregando análises concluídas…',
+  submitCaseAnalysisEmpty: 'Nenhuma análise forense concluída ainda. Abra o Laboratório Forense para solicitar uma.',
   submitCaseQuestionsHeader: 'Perguntas da Investigação',
   submitCaseSubmitButton: 'Submeter Caso',
   submitCaseAttemptsRemaining: '{n} tentativas restantes',
@@ -445,6 +447,14 @@ export const ptBR: Translations = {
   submitCaseBreakdownAnalysis: 'Análise',
   submitCaseBreakdownQuestions: 'Perguntas',
   submitCaseExplanationHeader: 'Explicação do Caso',
+  submitCaseProgressTitle: 'Checklist de Submissão',
+  submitCaseProgressSuspect: 'Suspeito',
+  submitCaseProgressEvidence: 'Evidências ({n})',
+  submitCaseProgressAnalysis: 'Análises ({n})',
+  submitCaseProgressQuestions: 'Perguntas ({a}/{b})',
+  submitCaseProgressReady: 'Pronto para submeter',
+  submitCaseProgressMissingSuspect: 'Selecione um suspeito principal',
+  submitCaseProgressMissingQuestions: 'Algumas perguntas não foram respondidas — você ainda pode submeter, mas perderá esses pontos',
 
   // Dashboard V2
   dashboardRequiredRank: 'Rank Necessário',

--- a/frontend/src/test/SubmitCase.test.tsx
+++ b/frontend/src/test/SubmitCase.test.tsx
@@ -87,6 +87,12 @@ vi.mock('../contexts/CaseContext', () => ({
   useSubmission: () => mockSubmissionState,
 }))
 
+vi.mock('../services/api', () => ({
+  forensicRequestApi: {
+    getForensicRequests: vi.fn(async () => [] as unknown[]),
+  },
+}))
+
 vi.mock('../contexts/LanguageContext', () => ({
   useLanguage: () => ({ t: (key: string) => key }),
   LanguageProvider: ({ children }: { children: React.ReactNode }) => children,

--- a/frontend/src/types/i18n.ts
+++ b/frontend/src/types/i18n.ts
@@ -437,6 +437,8 @@ export interface Translations {
   submitCaseSuspectLabel: string;
   submitCaseEvidenceLabel: string;
   submitCaseAnalysisLabel: string;
+  submitCaseAnalysisLoading: string;
+  submitCaseAnalysisEmpty: string;
   submitCaseQuestionsHeader: string;
   submitCaseSubmitButton: string;
   submitCaseAttemptsRemaining: string;
@@ -449,6 +451,14 @@ export interface Translations {
   submitCaseBreakdownAnalysis: string;
   submitCaseBreakdownQuestions: string;
   submitCaseExplanationHeader: string;
+  submitCaseProgressTitle: string;
+  submitCaseProgressSuspect: string;
+  submitCaseProgressEvidence: string;
+  submitCaseProgressAnalysis: string;
+  submitCaseProgressQuestions: string;
+  submitCaseProgressReady: string;
+  submitCaseProgressMissingSuspect: string;
+  submitCaseProgressMissingQuestions: string;
 
   // Dashboard V2
   dashboardRequiredRank: string;


### PR DESCRIPTION
## Submit Case UX — 3 melhorias

Quando o player abre o app **⚖️ Submit Case** pra resolver o caso, hoje encontra 3 atritos. Esta branch ataca todos.

### 1) Analysis IDs: textarea livre → multiselect de análises concluídas
Antes, o jogador precisava digitar à mão `asset.<id>:<AnalysisType>`, uma string que não aparece em nenhum lugar visível na UI. Agora a seção lista as análises forenses concluídas (de `forensicRequestApi.getForensicRequests` filtrando `status === 'completed'`) como checkboxes, e gera o id no formato exato esperado por `solution.requiredAnalysisIds`. Loading e empty states orientam o jogador a usar o Laboratório Forense.

### 2) Submission checklist
Quatro chips no topo (Suspect / Evidence / Analyses / Questions `X/Y`) mostram o progresso em tempo real e ativam um hint contextual quando algo falta. O botão Submit fica habilitado assim que um suspeito é escolhido — o backend aceita envios parciais e simplesmente zera os buckets não preenchidos.

### 3) Evidências ordenadas + badge de categoria
Assets de categoria forense aparecem primeiro e cada item ganha uma badge com a categoria, ajudando a distinguir relatórios forenses de evidências originais.

### i18n
Strings novas adicionadas em **pt-BR / en-US / es-ES / fr-FR** e declaradas no contrato `i18n.ts`.

### Validação
- `tsc --noEmit` ✅
- `eslint` ✅
- 25/25 testes (8 do SubmitCase, incluindo os 6 originais + verificação da nova mock de `forensicRequestApi`).
