### PR TITLE
fix(submit-case): resilient suspect dropdown + no-name-leakage in que…

### DIFF
--- a/frontend/src/components/apps/SubmitCase.tsx
+++ b/frontend/src/components/apps/SubmitCase.tsx
@@ -405,15 +405,20 @@ const SubmitCase: React.FC = () => {
           <Select
             value={suspectId}
             onChange={e => setSuspectId(e.target.value)}
-            disabled={isExhausted}
+            disabled={isExhausted || suspects.length === 0}
           >
             <option value="">—</option>
             {suspects.map(s => (
               <option key={s.id} value={s.id}>
-                {s.name}
+                {s.name?.trim() || s.alias?.trim() || s.id}
               </option>
             ))}
           </Select>
+          {suspects.length === 0 && (
+            <EmptyAnalyses>
+              {t('submitCaseSuspectsEmpty')}
+            </EmptyAnalyses>
+          )}
         </Section>
 
         <Section>

--- a/frontend/src/locales/en-US.ts
+++ b/frontend/src/locales/en-US.ts
@@ -447,6 +447,7 @@ export const enUS: Translations = {
   submitCaseBreakdownAnalysis: 'Analysis',
   submitCaseBreakdownQuestions: 'Questions',
   submitCaseExplanationHeader: 'Case Explanation',
+  submitCaseSuspectsEmpty: 'No suspects on file yet. Investigate further to reveal them.',
   submitCaseProgressTitle: 'Submission Checklist',
   submitCaseProgressSuspect: 'Suspect',
   submitCaseProgressEvidence: 'Evidence ({n})',

--- a/frontend/src/locales/es-ES.ts
+++ b/frontend/src/locales/es-ES.ts
@@ -447,6 +447,7 @@ export const esES: Translations = {
   submitCaseBreakdownAnalysis: 'Análisis',
   submitCaseBreakdownQuestions: 'Preguntas',
   submitCaseExplanationHeader: 'Explicación del Caso',
+  submitCaseSuspectsEmpty: 'Aún no hay sospechosos identificados. Investiga más para revelarlos.',
   submitCaseProgressTitle: 'Lista de Envío',
   submitCaseProgressSuspect: 'Sospechoso',
   submitCaseProgressEvidence: 'Evidencias ({n})',

--- a/frontend/src/locales/fr-FR.ts
+++ b/frontend/src/locales/fr-FR.ts
@@ -447,6 +447,7 @@ export const frFR: Translations = {
   submitCaseBreakdownAnalysis: 'Analyse',
   submitCaseBreakdownQuestions: 'Questions',
   submitCaseExplanationHeader: 'Explication du dossier',
+  submitCaseSuspectsEmpty: "Aucun suspect identifié pour le moment. Enquêtez davantage pour les révéler.",
   submitCaseProgressTitle: 'Liste de contrôle',
   submitCaseProgressSuspect: 'Suspect',
   submitCaseProgressEvidence: 'Preuves ({n})',

--- a/frontend/src/locales/pt-BR.ts
+++ b/frontend/src/locales/pt-BR.ts
@@ -447,6 +447,7 @@ export const ptBR: Translations = {
   submitCaseBreakdownAnalysis: 'Análise',
   submitCaseBreakdownQuestions: 'Perguntas',
   submitCaseExplanationHeader: 'Explicação do Caso',
+  submitCaseSuspectsEmpty: 'Nenhum suspeito identificado ainda. Investigue mais para revelá-los.',
   submitCaseProgressTitle: 'Checklist de Submissão',
   submitCaseProgressSuspect: 'Suspeito',
   submitCaseProgressEvidence: 'Evidências ({n})',

--- a/frontend/src/types/i18n.ts
+++ b/frontend/src/types/i18n.ts
@@ -451,6 +451,7 @@ export interface Translations {
   submitCaseBreakdownAnalysis: string;
   submitCaseBreakdownQuestions: string;
   submitCaseExplanationHeader: string;
+  submitCaseSuspectsEmpty: string;
   submitCaseProgressTitle: string;
   submitCaseProgressSuspect: string;
   submitCaseProgressEvidence: string;

--- a/functions/CaseGen.Functions/Services/CaseV2/Tasks/SolutionTasks.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Tasks/SolutionTasks.cs
@@ -111,7 +111,15 @@ Topic: ""{topic.Topic}"". Echo id `{topic.Id}` and `weight` {topic.Weight}.
 (four characters: o, p, t, dot) followed by lowercase letters/digits/underscores. NEVER use `opt_` or just `opt-`.
 All options must be plausible (no obvious distractors). One is the correct answer (`correctOptionId`), and it
 MUST be one of the `option.id` values you emit.
-Keep the prompt under 25 words.";
+Keep the prompt under 25 words.
+
+CRITICAL — NO NAME LEAKAGE:
+- This question is about WHAT happened (the topic above), NEVER about WHO did it.
+- DO NOT name any suspect, victim, or witness in the prompt or in any option label. Suspect
+  identification is captured as a separate field; revealing names here would spoil the case.
+- Refer to people generically (in the same language as the prompt): ""the perpetrator"",
+  ""the victim"", ""an accomplice"", ""the contact"", ""the witness"". Pick whichever generic role
+  fits the topic — never an actual name from the draft.";
         var user = $@"CASE DRAFT (read-only):
 {draft.ToSummaryJson()}
 
@@ -141,7 +149,82 @@ Emit JSON only.";
             _logger.LogWarning("Question {Id} correctOptionId {Correct} not in options — defaulting to first", q.Id, q.CorrectOptionId);
             q.CorrectOptionId = q.Options[0].Id;
         }
+
+        // Defensive: if the LLM ignored the no-name-leakage rule, scrub the surface forms.
+        // We replace whole-word occurrences of each suspect's full name, given name, family name,
+        // and alias with a neutral placeholder so the player never sees a spoiler.
+        ScrubSuspectNames(q, draft);
+
         return q;
+    }
+
+    /// <summary>
+    /// Best-effort scrub of suspect surface forms in a question's prompt and option labels.
+    /// Logs a warning when a leak is detected so we can tighten the upstream prompt over time.
+    /// </summary>
+    private void ScrubSuspectNames(SolutionQuestion q, CaseDraft draft)
+    {
+        var tokens = BuildSuspectSurfaceForms(draft);
+        if (tokens.Count == 0) return;
+
+        var leakedIn = new List<string>();
+
+        var newPrompt = ReplaceSurfaceForms(q.Prompt, tokens, out var promptHits);
+        if (promptHits > 0) { q.Prompt = newPrompt; leakedIn.Add("prompt"); }
+
+        for (int i = 0; i < q.Options.Count; i++)
+        {
+            var label = q.Options[i].Label;
+            var replaced = ReplaceSurfaceForms(label, tokens, out var optHits);
+            if (optHits > 0)
+            {
+                q.Options[i].Label = replaced;
+                leakedIn.Add($"option[{i}]");
+            }
+        }
+
+        if (leakedIn.Count > 0)
+            _logger.LogWarning("Question {Id} leaked suspect name(s) in {Where} — scrubbed with placeholder", q.Id, string.Join(",", leakedIn));
+    }
+
+    private static List<string> BuildSuspectSurfaceForms(CaseDraft draft)
+    {
+        var forms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var s in draft.SuspectFull)
+        {
+            void Add(string? v)
+            {
+                if (string.IsNullOrWhiteSpace(v)) return;
+                var t = v.Trim();
+                if (t.Length < 3) return; // skip initials that would over-match
+                forms.Add(t);
+            }
+            Add(s.Name);
+            if (!string.IsNullOrWhiteSpace(s.Name))
+            {
+                var parts = s.Name.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                foreach (var p in parts) Add(p);
+            }
+        }
+        // Longest first so multi-word matches win over individual tokens.
+        return forms.OrderByDescending(f => f.Length).ToList();
+    }
+
+    private static string ReplaceSurfaceForms(string text, List<string> tokens, out int hits)
+    {
+        hits = 0;
+        if (string.IsNullOrEmpty(text)) return text;
+        var result = text;
+        foreach (var token in tokens)
+        {
+            // Whole-word, case-insensitive replacement. Escape regex specials in the token.
+            var pattern = "\\b" + System.Text.RegularExpressions.Regex.Escape(token) + "\\b";
+            var matches = System.Text.RegularExpressions.Regex.Matches(result, pattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            if (matches.Count == 0) continue;
+            hits += matches.Count;
+            result = System.Text.RegularExpressions.Regex.Replace(result, pattern, "[redacted]", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
+        return result;
     }
 }
 


### PR DESCRIPTION
…stions

Two issues hit while solving a freshly generated pt-BR case:

1. Suspect dropdown rendered empty rows. Root cause: the `<option>` was blindly using `s.name`, so any suspect whose `name` arrived as an empty/whitespace string from the LLM (or an older case payload) showed up as an unclickable blank entry. Fix: fall back through `name -> alias -> id` so every option is always labelled, and surface an explicit empty-state message + disable the dropdown when zero suspects are visible.

2. Investigation questions were leaking suspect names in the prompt and option labels, spoiling the case (e.g. "Qual o motivo de Marcos da Silva?" instead of "Qual o motivo do perpetrador?"). Two-layer fix in `QuestionTask`:

   - **Prompt:** added an explicit CRITICAL block instructing the model that questions are about WHAT happened, never WHO, and that suspects must always be referred to by generic role (the perpetrator, the victim, an accomplice, the contact, the witness).

   - **Defensive post-process:** `ScrubSuspectNames` walks the prompt and every option label, replaces whole-word matches of each suspect name (and its individual tokens, ≥3 chars to avoid matching initials) with `[redacted]`, and logs a warning identifying which question/option leaked. This guarantees the player never sees a spoiler even when the model ignores the instruction.

i18n: new `submitCaseSuspectsEmpty` key in all 4 locales + i18n.ts.

Tests: 19/19 functions tests, 8/8 SubmitCase frontend tests, tsc clean.