### PR TITLE
fix(cases): seed initial suspects into session reveal list

### DIFF
--- a/backend/CaseZeroApi/Controllers/CasesController.cs
+++ b/backend/CaseZeroApi/Controllers/CasesController.cs
@@ -114,7 +114,22 @@ public class CasesController : ControllerBase
         await EnsureSessionAndInitialVisibilityAsync(caseId, userId, ct);
 
         var data = await _storage.GetForUserAsync(caseId, userId, ct);
-        return data is null ? NotFound(new { error = $"Case not found: {caseId}" }) : Ok(data);
+        if (data is null) return NotFound(new { error = $"Case not found: {caseId}" });
+
+        // Diagnostic: if the sanitized response surfaces no suspects, the player can't solve
+        // the case. Surface enough context to debug both LLM-generation bugs (raw count = 0)
+        // and visibility-filter bugs (raw count > 0 but sanitized = 0).
+        if (data.Suspects.Count == 0)
+        {
+            var raw = await _storage.GetRawAsync(caseId, ct);
+            _logger.LogWarning(
+                "GetCase {CaseId} returned 0 suspects to user {UserId}. Raw suspect count={Raw}, raw visibilities=[{Vis}]",
+                caseId, userId,
+                raw?.Suspects.Count ?? 0,
+                raw is null ? "" : string.Join(",", raw.Suspects.Select(s => $"{s.Id}:{s.Visibility}")));
+        }
+
+        return Ok(data);
     }
 
     private async Task EnsureSessionAndInitialVisibilityAsync(string caseId, string userId, CancellationToken ct)
@@ -180,6 +195,44 @@ public class CasesController : ControllerBase
                 EmailId = email.Id,
                 UnlockedAt = DateTime.UtcNow
             });
+        }
+
+        // 4) Seed revealed suspects. The sanitizer filters suspects by
+        //    `visibility == "initial" || revealedSuspectIds.Contains(id)` — so writing the
+        //    initially-visible (or all, when unlockMode == all_initial) suspect ids onto the
+        //    CaseSession guarantees they reach the client even if the case JSON arrived with
+        //    a missing/wrong visibility on individual suspects (older generations, partial
+        //    sanitization upstream, etc.).
+        var session = await _db.CaseSessions
+            .Where(cs => cs.UserId == userId && cs.CaseId == caseId)
+            .OrderByDescending(cs => cs.SessionStart)
+            .FirstOrDefaultAsync(ct);
+        if (session is null)
+        {
+            // We just added one above; reload it within the same DbContext so we mutate the
+            // entity that EF Core tracks (avoids a second .Add for the same key).
+            await _db.SaveChangesAsync(ct);
+            session = await _db.CaseSessions
+                .Where(cs => cs.UserId == userId && cs.CaseId == caseId)
+                .OrderByDescending(cs => cs.SessionStart)
+                .FirstAsync(ct);
+        }
+        var revealedSuspectIds = string.IsNullOrWhiteSpace(session.RevealedSuspectIds)
+            ? new List<string>()
+            : System.Text.Json.JsonSerializer.Deserialize<List<string>>(session.RevealedSuspectIds) ?? new();
+        var revealedSet = new HashSet<string>(revealedSuspectIds, StringComparer.Ordinal);
+        var initialSuspectsAdded = 0;
+        foreach (var suspect in raw.Suspects)
+        {
+            var shouldReveal = unlockAll ||
+                               string.IsNullOrWhiteSpace(suspect.Visibility) ||
+                               string.Equals(suspect.Visibility, "initial", StringComparison.OrdinalIgnoreCase);
+            if (!shouldReveal) continue;
+            if (revealedSet.Add(suspect.Id)) initialSuspectsAdded++;
+        }
+        if (initialSuspectsAdded > 0)
+        {
+            session.RevealedSuspectIds = System.Text.Json.JsonSerializer.Serialize(revealedSet.ToList());
         }
 
         await _db.SaveChangesAsync(ct);

--- a/backend/CaseZeroApi/Services/CaseV2SanitizerService.cs
+++ b/backend/CaseZeroApi/Services/CaseV2SanitizerService.cs
@@ -97,9 +97,15 @@ public class CaseV2SanitizerService : ICaseV2SanitizerService
 
         if (syntheticEmails is not null) emails.AddRange(syntheticEmails);
 
-        // Suspects: initial + revealed; apply status & alibi overrides
+        // Suspects: initial + revealed; apply status & alibi overrides.
+        // We treat null/empty visibility as "initial" (older case payloads sometimes lack the
+        // field). EnsureSessionAndInitialVisibilityAsync on the controller side also seeds
+        // these ids into revealedSuspectIds at first access, which is the canonical fix —
+        // this OR-branch on null visibility is the belt-and-braces backstop.
         var suspects = caseData.Suspects
-            .Where(s => s.Visibility == "initial" || revealedSuspectIds.Contains(s.Id))
+            .Where(s => string.IsNullOrWhiteSpace(s.Visibility)
+                        || string.Equals(s.Visibility, "initial", StringComparison.OrdinalIgnoreCase)
+                        || revealedSuspectIds.Contains(s.Id))
             .Select(s => ApplyOverrides(s, statusOverrides, alibiOverrides))
             .ToList();
 


### PR DESCRIPTION
The Submit Case suspect dropdown was empty for some generated cases. Root cause: the sanitizer filters suspects by `visibility == 'initial' OR revealedSuspectIds.contains(id)`, but EnsureSessionAndInitialVisibilityAsync only seeded visible assets and emails. Any suspect whose visibility was missing, blank, or set to anything other than 'initial' silently disappeared.

Changes:
- CasesController.EnsureSessionAndInitialVisibilityAsync now also unions the initially-visible (or all, when unlockMode == all_initial) suspect ids into CaseSession.RevealedSuspectIds, matching the existing asset/email pattern.
- CaseV2SanitizerService.SanitizeForUserAsync treats null/empty visibility as 'initial' (defense in depth for older or partially-generated payloads).
- GetCase logs a warning with raw suspect count + visibilities when the sanitized response surfaces zero suspects, so we can tell apart a generator/LLM bug (raw=0) from a visibility-filter bug (raw>0, sanitized=0).