### PR TITLE
debug: log suspects state on every SubmitCase render

### DIFF
--- a/frontend/src/components/apps/SubmitCase.tsx
+++ b/frontend/src/components/apps/SubmitCase.tsx
@@ -250,6 +250,18 @@ const SubmitCase: React.FC = () => {
   const suspects = useSuspects()
   const submission = useSubmission()
 
+  // TEMP DEBUG: prints on every render so we can see what the runtime state looks like
+  // for users who reported an empty suspect dropdown. Remove once root cause is confirmed.
+  if (typeof window !== 'undefined') {
+    console.log('[SubmitCase debug] render', {
+      caseId: state.case?.caseId,
+      suspectsLength: suspects.length,
+      suspectsSample: suspects.slice(0, 2).map(s => ({ id: s.id, name: s.name })),
+      stateCaseSuspectsLength: state.case?.suspects?.length,
+      assetsLength: assets.length,
+    })
+  }
+
   const caseId = state.case?.caseId
   const questions = useMemo(() => state.case?.solution.questions ?? [], [state.case])
   const attemptsRemaining = submission.maxAttempts - submission.attemptsUsed


### PR DESCRIPTION
Temporary debug PR. Adds a single console.log in SubmitCase to dump:
- state.case?.caseId
- suspects.length (from useSuspects())
- first 2 suspects' id+name
- state.case?.suspects?.length (raw)
- assets.length

We're diagnosing why a user sees an empty Suspect dropdown even though GET /api/cases/{id} returns 5 suspects in the network response. Will be reverted once we confirm root cause.