### PR TITLE
fix(submit-case): replace native <select> with card-based radio picker

### DIFF
--- a/frontend/src/components/apps/SubmitCase.tsx
+++ b/frontend/src/components/apps/SubmitCase.tsx
@@ -57,23 +57,45 @@ const SectionTitle = styled.h4`
   padding-bottom: 0.4rem;
 `
 
-const Select = styled.select`
-  padding: 0.6rem;
-  background: rgba(0, 0, 0, 0.3);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-  color: white;
-  font-size: 13px;
-  /* Tells the OS-rendered native dropdown popup to use the dark palette.
-     Without this, Chromium on Windows ignores the option { background } rule
-     below and renders the popup with OS defaults — which keeps the inherited
-     'color: white' but uses a light background, producing white-on-white
-     unreadable text. */
-  color-scheme: dark;
+// Card-based suspect picker. We deliberately avoid native <select> here:
+// Chromium on Windows renders the option popup through the OS shell and
+// frequently strips author CSS, producing unreadable text even with
+// color-scheme: dark. A grid of styled radio cards gives us full styling
+// control across platforms and matches the look of the question options.
+const SuspectGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.5rem;
+`
 
-  option {
-    background: #1a1a2e;
-    color: white;
+const SuspectCard = styled.label<{ $selected: boolean; $disabled: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 6px;
+  border: 1px solid ${props => (props.$selected ? 'rgba(74, 158, 255, 0.8)' : 'rgba(255, 255, 255, 0.12)')};
+  background: ${props => (props.$selected ? 'rgba(74, 158, 255, 0.12)' : 'rgba(0, 0, 0, 0.25)')};
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 13px;
+  cursor: ${props => (props.$disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${props => (props.$disabled ? 0.5 : 1)};
+  transition: background 120ms ease, border-color 120ms ease;
+
+  &:hover {
+    background: ${props =>
+      props.$disabled
+        ? props.$selected
+          ? 'rgba(74, 158, 255, 0.12)'
+          : 'rgba(0, 0, 0, 0.25)'
+        : props.$selected
+          ? 'rgba(74, 158, 255, 0.18)'
+          : 'rgba(255, 255, 255, 0.05)'};
+  }
+
+  input {
+    margin: 0;
+    accent-color: #4a9eff;
   }
 `
 
@@ -408,22 +430,32 @@ const SubmitCase: React.FC = () => {
       <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
         <Section>
           <SectionTitle>{t('submitCaseSuspectLabel')}</SectionTitle>
-          <Select
-            value={suspectId}
-            onChange={e => setSuspectId(e.target.value)}
-            disabled={isExhausted || suspects.length === 0}
-          >
-            <option value="">—</option>
-            {suspects.map(s => (
-              <option key={s.id} value={s.id}>
-                {s.name?.trim() || s.alias?.trim() || s.id}
-              </option>
-            ))}
-          </Select>
-          {suspects.length === 0 && (
-            <EmptyAnalyses>
-              {t('submitCaseSuspectsEmpty')}
-            </EmptyAnalyses>
+          {suspects.length === 0 ? (
+            <EmptyAnalyses>{t('submitCaseSuspectsEmpty')}</EmptyAnalyses>
+          ) : (
+            <SuspectGrid role="radiogroup" aria-label={t('submitCaseSuspectLabel')}>
+              {suspects.map(s => {
+                const label = s.name?.trim() || s.alias?.trim() || s.id
+                const selected = suspectId === s.id
+                return (
+                  <SuspectCard
+                    key={s.id}
+                    $selected={selected}
+                    $disabled={isExhausted}
+                  >
+                    <input
+                      type="radio"
+                      name="submit-case-suspect"
+                      value={s.id}
+                      checked={selected}
+                      onChange={() => setSuspectId(s.id)}
+                      disabled={isExhausted}
+                    />
+                    <span>{label}</span>
+                  </SuspectCard>
+                )
+              })}
+            </SuspectGrid>
           )}
         </Section>
 

--- a/frontend/src/test/SubmitCase.test.tsx
+++ b/frontend/src/test/SubmitCase.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import '@testing-library/jest-dom'
 
 import type { SubmitCaseRequest, SubmitCaseResult } from '../types/caseV2'
@@ -114,12 +114,15 @@ describe('SubmitCase', () => {
     mockSubmissionState = { attemptsUsed: 0, maxAttempts: 3, lastResult: undefined }
   })
 
-  it('renders visible suspects as select options', () => {
+  it('renders visible suspects as selectable cards', () => {
     render(<SubmitCase />)
-    const select = screen.getByRole('combobox')
-    expect(select).toBeInTheDocument()
+    // Suspects are now rendered as radio buttons within a radiogroup
+    const group = screen.getByRole('radiogroup', { name: /suspect/i })
+    expect(group).toBeInTheDocument()
     expect(screen.getByText('Marcus Reeve')).toBeInTheDocument()
     expect(screen.getByText('Alice Turner')).toBeInTheDocument()
+    // Scope to the suspect group to avoid counting question-option radios too
+    expect(within(group).getAllByRole('radio')).toHaveLength(mockSuspects.length)
   })
 
   it('renders visible assets as evidence checkboxes', () => {
@@ -145,7 +148,7 @@ describe('SubmitCase', () => {
 
     render(<SubmitCase />)
 
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'suspect.marcus' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Marcus Reeve' }))
     fireEvent.click(screen.getAllByRole('checkbox')[0])
     fireEvent.click(screen.getByRole('button'))
 
@@ -164,7 +167,7 @@ describe('SubmitCase', () => {
     })
 
     const { rerender } = render(<SubmitCase />)
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'suspect.marcus' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Marcus Reeve' }))
     fireEvent.click(screen.getByRole('button'))
 
     // Wait for submitCase to resolve and re-render with updated state
@@ -198,7 +201,7 @@ describe('SubmitCase', () => {
     mockSubmissionState = { attemptsUsed: 2, maxAttempts: 3, lastResult: undefined }
 
     const { rerender } = render(<SubmitCase />)
-    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'suspect.marcus' } })
+    fireEvent.click(screen.getByRole('radio', { name: 'Marcus Reeve' }))
     fireEvent.click(screen.getByRole('button'))
 
     await waitFor(() => expect(mockSubmitCase).toHaveBeenCalledOnce())


### PR DESCRIPTION
## Problem

After PR #147 (color-scheme tweak) shipped, the user confirmed the suspect dropdown is still unusable on their Windows playthrough. Inspection in DevTools proved the data is correct end-to-end (API returns 5 suspects, React state has 5, DOM has 6 `<option>` elements, select not disabled) — the failure is the OS-rendered native popup itself: Chromium on Windows strips author CSS on `<option>` while preserving inherited `color: white`, so the menu renders white-on-white. `color-scheme: dark` was unreliable across Windows themes.

User explicitly asked: ""Nao tem jeito. Nao funciona o drop down... Quer tentar usar radio button ou select como nas perguntas?""

## Fix

Replace the native `<select>` with a card-based radio picker matching the existing question UI pattern. Removes the OS-popup dependency entirely.

- Drop the `Select` styled-component.
- Add `SuspectGrid` + `SuspectCard` (auto-fill grid of selectable label cards; selected / disabled / hover states; `accent-color` for the radio dot).
- Each card is a `<label>` wrapping a hidden `<input type=""radio"" name=""submit-case-suspect"">`.
- `role=""radiogroup""` on the grid with the existing `submitCaseSuspectLabel` for accessibility (already shipped in all 4 locales).
- Tests updated to drive selection via `getByRole('radio', { name })` and scope the count assertion to the suspect radiogroup (questions also render radios).

## Verification

- `npm test -- --run` → 25/25 ✅
- `npm run build` ✅
- Lint clean on changed files.

After merge: hard refresh in prod and select a suspect by clicking its card.
