### PR TITLE
feat(dashboard): real stats and recent activity from submissions

### DIFF
--- a/backend/CaseZeroApi/Controllers/CasesController.cs
+++ b/backend/CaseZeroApi/Controllers/CasesController.cs
@@ -93,6 +93,8 @@ public class CasesController : ControllerBase
 
         // averageRating: average score of graded CORRECT submissions, on a 0–100 scale,
         // taking only the best score per case (so multiple bad attempts don't drag it down).
+        // CaseSubmission.Score is already stored as 0..100 (SolutionService writes total*100),
+        // so no further scaling is required.
         var bestScoreByCase = mySubs
             .Where(s => s.IsCorrectSuspect && s.Graded)
             .GroupBy(s => s.CaseId, StringComparer.OrdinalIgnoreCase)
@@ -100,7 +102,7 @@ public class CasesController : ControllerBase
             .ToList();
         var averageRating = bestScoreByCase.Count == 0
             ? 0.0
-            : Math.Round(bestScoreByCase.Average() * 100.0, 1);
+            : Math.Round(bestScoreByCase.Average(), 1);
 
         // ── Recent activities (last 10) ────────────────────────────────────
         // The frontend renders these from a localized template keyed by `type`,
@@ -117,7 +119,7 @@ public class CasesController : ControllerBase
                 caseId = s.CaseId,
                 caseTitle = caseTitleById.TryGetValue(s.CaseId, out var t) ? t : s.CaseId,
                 date = s.SubmittedAt,
-                score = Math.Round(s.Score * 100.0, 1),
+                score = Math.Round(s.Score, 1),
                 graded = s.Graded
             };
         }).ToList();

--- a/backend/CaseZeroApi/Controllers/CasesController.cs
+++ b/backend/CaseZeroApi/Controllers/CasesController.cs
@@ -54,14 +54,82 @@ public class CasesController : ControllerBase
         if (locked > 0)
             _logger.LogInformation("Dashboard hid {N} case(s) above user rank {Rank}", locked, userRank);
 
+        // ── Compute stats from CaseSubmissions ──────────────────────────────
+        // Only graded submissions count toward promotion-style stats. Ungraded
+        // attempts (after the player exhausts their MaxAttempts) are excluded.
+        var mySubs = string.IsNullOrEmpty(userId)
+            ? new List<CaseSubmissionSummary>()
+            : await _db.CaseSubmissions.AsNoTracking()
+                .Where(s => s.SubmittedByUserId == userId)
+                .OrderByDescending(s => s.SubmittedAt)
+                .Select(s => new CaseSubmissionSummary
+                {
+                    CaseId = s.CaseId,
+                    SubmittedAt = s.SubmittedAt,
+                    IsCorrectSuspect = s.IsCorrectSuspect,
+                    Score = s.Score,
+                    Graded = s.Graded,
+                    AttemptNumber = s.AttemptNumber
+                })
+                .ToListAsync(ct);
+
+        var resolvedCaseIds = mySubs
+            .Where(s => s.IsCorrectSuspect && s.Graded)
+            .Select(s => s.CaseId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var attemptedCaseIds = mySubs
+            .Where(s => s.Graded)
+            .Select(s => s.CaseId)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var casesResolved = resolvedCaseIds.Count;
+        var casesActive = Math.Max(0, cases.Count - casesResolved);
+        var successRate = attemptedCaseIds.Count == 0
+            ? 0.0
+            : Math.Round((double)casesResolved / attemptedCaseIds.Count * 100.0, 1);
+
+        // averageRating: average score of graded CORRECT submissions, on a 0–100 scale,
+        // taking only the best score per case (so multiple bad attempts don't drag it down).
+        var bestScoreByCase = mySubs
+            .Where(s => s.IsCorrectSuspect && s.Graded)
+            .GroupBy(s => s.CaseId, StringComparer.OrdinalIgnoreCase)
+            .Select(g => g.Max(x => x.Score))
+            .ToList();
+        var averageRating = bestScoreByCase.Count == 0
+            ? 0.0
+            : Math.Round(bestScoreByCase.Average() * 100.0, 1);
+
+        // ── Recent activities (last 10) ────────────────────────────────────
+        // The frontend renders these from a localized template keyed by `type`,
+        // so we don't translate on the backend — we just ship structured rows.
+        var caseTitleById = cases.ToDictionary(c => c.CaseId, c => c.Title, StringComparer.OrdinalIgnoreCase);
+        var recentActivities = mySubs.Take(10).Select(s =>
+        {
+            string type = s.IsCorrectSuspect
+                ? (s.Graded ? "resolved" : "resolved_ungraded")
+                : (s.Graded ? "attempted" : "attempted_ungraded");
+            return new
+            {
+                type,
+                caseId = s.CaseId,
+                caseTitle = caseTitleById.TryGetValue(s.CaseId, out var t) ? t : s.CaseId,
+                date = s.SubmittedAt,
+                score = Math.Round(s.Score * 100.0, 1),
+                graded = s.Graded
+            };
+        }).ToList();
+
         return Ok(new
         {
             stats = new
             {
-                casesResolved = 0,
-                casesActive = cases.Count,
-                successRate = 0.0,
-                averageRating = 0.0
+                casesResolved,
+                casesActive,
+                successRate,
+                averageRating
             },
             cases = cases.Select(c => new
             {
@@ -73,10 +141,21 @@ public class CasesController : ControllerBase
                 estimatedDurationMinutes = c.EstimatedDurationMinutes,
                 briefing = c.Briefing,
                 tags = c.Tags,
-                requiredRank = c.RequiredRank
+                requiredRank = c.RequiredRank,
+                isResolved = resolvedCaseIds.Contains(c.CaseId)
             }).ToList(),
-            recentActivities = Array.Empty<object>()
+            recentActivities
         });
+    }
+
+    private sealed class CaseSubmissionSummary
+    {
+        public string CaseId { get; set; } = string.Empty;
+        public DateTime SubmittedAt { get; set; }
+        public bool IsCorrectSuspect { get; set; }
+        public double Score { get; set; }
+        public bool Graded { get; set; }
+        public int AttemptNumber { get; set; }
     }
 
     /// <summary>

--- a/frontend/src/locales/en-US.ts
+++ b/frontend/src/locales/en-US.ts
@@ -97,6 +97,11 @@ export const enUS: Translations = {
   noRecentActivity: 'No recent activity logged.',
   noDataAvailable: 'No operational data available.',
   viewDossier: 'View Dossier',
+  resolvedBadge: 'Resolved',
+  activityResolved: 'Resolved case {title}',
+  activityResolvedUngraded: 'Solved {title} (practice mode, not counted)',
+  activityAttempted: 'Submitted an answer for {title}',
+  activityAttemptedUngraded: 'Practice attempt on {title}',
   
   // Desktop
   evidence: 'Evidence',

--- a/frontend/src/locales/es-ES.ts
+++ b/frontend/src/locales/es-ES.ts
@@ -95,8 +95,13 @@ export const esES: Translations = {
   evidenceProgress: 'Progreso de evidencias',
   commandBulletins: 'Boletines de mando',
   noRecentActivity: 'No hay actividad reciente registrada.',
-  noDataAvailable: 'No hay datos operativos disponibles.',
-  viewDossier: 'Ver dossier',
+  noDataAvailable: 'Sin datos operativos disponibles.',
+  viewDossier: 'Ver expediente',
+  resolvedBadge: 'Resuelto',
+  activityResolved: 'Caso {title} resuelto',
+  activityResolvedUngraded: 'Resolvió {title} (modo práctica, no cuenta)',
+  activityAttempted: 'Envió una respuesta para {title}',
+  activityAttemptedUngraded: 'Intento en modo práctica en {title}',
   
   // Desktop
   evidence: 'Evidencias',

--- a/frontend/src/locales/fr-FR.ts
+++ b/frontend/src/locales/fr-FR.ts
@@ -97,6 +97,11 @@ export const frFR: Translations = {
   noRecentActivity: 'Aucune activité récente enregistrée.',
   noDataAvailable: 'Aucune donnée opérationnelle disponible.',
   viewDossier: 'Voir le dossier',
+  resolvedBadge: 'Résolu',
+  activityResolved: 'Affaire {title} résolue',
+  activityResolvedUngraded: 'A résolu {title} (mode entraînement, non comptabilisé)',
+  activityAttempted: 'A soumis une réponse pour {title}',
+  activityAttemptedUngraded: 'Tentative en mode entraînement sur {title}',
   
   // Desktop
   evidence: 'Preuves',

--- a/frontend/src/locales/pt-BR.ts
+++ b/frontend/src/locales/pt-BR.ts
@@ -95,8 +95,13 @@ export const ptBR: Translations = {
   evidenceProgress: 'Progresso de evidências',
   commandBulletins: 'Boletins de comando',
   noRecentActivity: 'Nenhuma atividade recente registrada.',
-  noDataAvailable: 'Nenhum dado operacional disponível.',
-  viewDossier: 'Ver dossiê',
+  noDataAvailable: 'Sem dados operacionais disponíveis.',
+  viewDossier: 'Ver Dossiê',
+  resolvedBadge: 'Resolvido',
+  activityResolved: 'Caso {title} resolvido',
+  activityResolvedUngraded: 'Resolveu {title} (modo prática, não conta)',
+  activityAttempted: 'Enviou uma resposta para {title}',
+  activityAttemptedUngraded: 'Tentativa em modo prática em {title}',
   
   // Desktop
   evidence: 'Evidências',

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import { Briefcase, Clock, MapPin, ArrowRight, Shield, Target, Activity, FileTex
 import { useAuth } from '../hooks/useAuthContext'
 import { useLanguage } from '../hooks/useLanguageContext'
 import { casesV2Api } from '../services/api'
-import type { CaseDashboardItem } from '../types/caseV2'
+import type { CaseDashboardItem, DashboardActivity } from '../types/caseV2'
 import LanguageSelector from '../components/LanguageSelector'
 import departmentBadge from '../assets/LogoMetroPolice_transparent.png'
 
@@ -230,6 +230,20 @@ const Tag = styled.span`
   border: 1px solid rgba(56, 189, 248, 0.25);
 `
 
+const ResolvedBadge = styled.span`
+  font-size: 0.7rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+  border: 1px solid rgba(34, 197, 94, 0.45);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+`
+
 const EmptyMessage = styled.div`
   padding: 2rem;
   text-align: center;
@@ -323,7 +337,7 @@ const DashboardPage = () => {
   const { t } = useLanguage()
   const [cases, setCases] = useState<CaseDashboardItem[]>([])
   const [stats, setStats] = useState<{ casesResolved: number; casesActive: number; successRate: number; averageRating: number } | null>(null)
-  const [activities, setActivities] = useState<Array<{ description: string; date: string; type?: string; caseId?: string }>>([])
+  const [activities, setActivities] = useState<DashboardActivity[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -367,6 +381,23 @@ const DashboardPage = () => {
     navigate(`/desktop/${caseId}`)
   }
 
+  // Render the activity row text, choosing a localized template based on `type`
+  // or falling back to a legacy `description` if the backend still ships one.
+  const renderActivity = (a: DashboardActivity): string => {
+    if (a.description) return a.description
+    const title = a.caseTitle ?? a.caseId ?? ''
+    const template = (() => {
+      switch (a.type) {
+        case 'resolved':            return t('activityResolved')
+        case 'resolved_ungraded':   return t('activityResolvedUngraded')
+        case 'attempted':           return t('activityAttempted')
+        case 'attempted_ungraded':  return t('activityAttemptedUngraded')
+        default:                    return ''
+      }
+    })()
+    return template.replace('{title}', title)
+  }
+
   return (
     <PageContainer>
       <BackgroundGrid />
@@ -407,7 +438,7 @@ const DashboardPage = () => {
         </StatCard>
         <StatCard>
           <StatLabel>{t('averageRating')}</StatLabel>
-          <StatValue><Activity size={20} />{stats?.averageRating ?? 0}</StatValue>
+          <StatValue><Activity size={20} />{stats?.averageRating ?? 0}%</StatValue>
         </StatCard>
       </StatsGrid>
 
@@ -429,7 +460,9 @@ const DashboardPage = () => {
               <CaseCard key={c.caseId} onClick={() => handleCaseClick(c.caseId)}>
                 <CardTitle>
                   <span>{c.title}</span>
-                  <ArrowRight size={16} />
+                  {c.isResolved
+                    ? <ResolvedBadge><CheckCircle size={12} />{t('resolvedBadge')}</ResolvedBadge>
+                    : <ArrowRight size={16} />}
                 </CardTitle>
                 <CardDescription>{c.description}</CardDescription>
                 <MetaRow>
@@ -477,7 +510,7 @@ const DashboardPage = () => {
             <ActivityList>
               {activities.slice(0, 8).map((a, i) => (
                 <ActivityItem key={`${a.date}-${i}`}>
-                  <span>{a.description}</span>
+                  <span>{renderActivity(a)}</span>
                   <ActivityMeta>
                     {new Date(a.date).toLocaleString()}
                     {a.caseId ? ` · ${a.caseId}` : ''}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -753,13 +753,13 @@ export const forensicsApi = {
 }
 
 // ── V2 Cases API ─────────────────────────────────────────────────────────────
-import type { CaseV2Sanitized, SubmitCaseRequest, SubmitCaseResult, CaseDashboardItem } from '../types/caseV2'
+import type { CaseV2Sanitized, SubmitCaseRequest, SubmitCaseResult, CaseDashboardItem, DashboardActivity } from '../types/caseV2'
 
 export const casesV2Api = {
   getDashboard: async (): Promise<{
     cases: CaseDashboardItem[]
     stats?: { casesResolved: number; casesActive: number; successRate: number; averageRating: number }
-    recentActivities?: Array<{ description: string; date: string; type?: string; caseId?: string }>
+    recentActivities?: DashboardActivity[]
   }> =>
     apiFetch('/cases/dashboard'),
 

--- a/frontend/src/types/caseV2.ts
+++ b/frontend/src/types/caseV2.ts
@@ -135,6 +135,24 @@ export interface CaseDashboardItem {
   category?: string
   tags?: string[]
   estimatedDurationMinutes?: number
+  isResolved?: boolean
+}
+
+export type DashboardActivityType =
+  | 'resolved'
+  | 'resolved_ungraded'
+  | 'attempted'
+  | 'attempted_ungraded'
+
+export interface DashboardActivity {
+  // Legacy free-form description; newer payloads use `type` + caseTitle.
+  description?: string
+  date: string
+  type?: DashboardActivityType
+  caseId?: string
+  caseTitle?: string
+  score?: number
+  graded?: boolean
 }
 
 // Submit request/result

--- a/frontend/src/types/i18n.ts
+++ b/frontend/src/types/i18n.ts
@@ -120,6 +120,11 @@ export interface Translations {
   noRecentActivity: string;
   noDataAvailable: string;
   viewDossier: string;
+  resolvedBadge: string;
+  activityResolved: string;
+  activityResolvedUngraded: string;
+  activityAttempted: string;
+  activityAttemptedUngraded: string;
   
   // Footer
   currentLanguage: string;


### PR DESCRIPTION
## Why

After PR #150, the player could resolve a case but nothing on the dashboard updated. **Stats** (Cases Resolved, Active, Success Rate, Avg Rating) and **Recent History** were hardcoded to `0` / `[]` in `CasesController.GetDashboard`.

## What

### Backend (`CasesController.cs`)
- Pulls the caller's own submissions from `CaseSubmissions` (no schema changes).
- Computes the 4 stat values from graded submissions:
  - **casesResolved** = distinct `CaseId` where `IsCorrectSuspect=true && Graded=true`
  - **casesActive** = visible cases - resolved (clamped at 0)
  - **successRate** = resolved / attempted (graded) × 100
  - **averageRating** = avg of *best* graded-correct score per case × 100
- Adds `isResolved` to each case in the response so the UI can show a badge.
- `recentActivities` ships the player's last 10 submissions as `{ type, caseId, caseTitle, date, score, graded }` rows. Backend never translates — frontend picks the right localized template by `type`.

### Frontend (`DashboardPage.tsx` + types + i18n)
- New `DashboardActivity` / `DashboardActivityType` in `types/caseV2.ts`.
- `CaseDashboardItem.isResolved` shown as a green ✓ **Resolved** badge.
- `renderActivity()` picks a localized template based on `type` and substitutes `{title}`.
- `averageRating` rendered with `%` suffix for consistency with `successRate`.

### i18n (en-US / pt-BR / es-ES / fr-FR)
5 new keys: `resolvedBadge`, `activityResolved`, `activityResolvedUngraded`, `activityAttempted`, `activityAttemptedUngraded`.

## Activity types
| `type` | Meaning |
|---|---|
| `resolved` | Correct + graded (counts for promotion) |
| `resolved_ungraded` | Correct after attempts exhausted (practice mode) |
| `attempted` | Wrong, graded attempt |
| `attempted_ungraded` | Wrong, practice mode |

## Tests
- Backend **65 / 65** ✅
- Frontend **25 / 25** ✅
- `npm run build` clean ✅

## Notes
- Only **graded** correct submissions count toward the resolved/successRate/averageRating stats. This is consistent with PR #150's policy: practice-mode solves don't promote.
- No new DB queries on hot paths — single `CaseSubmissions` scan filtered by `SubmittedByUserId`.