### PR TITLE
fix(casegen): replace audio asset with AudioTranscript document

### DIFF
--- a/functions/CaseGen.Functions.Tests/CaseV2/DocumentLayoutSmokeTests.cs
+++ b/functions/CaseGen.Functions.Tests/CaseV2/DocumentLayoutSmokeTests.cs
@@ -23,6 +23,7 @@ public class DocumentLayoutSmokeTests
     private static readonly string[] AllLayouts =
     {
         "GeneralReport","PoliceReport","WitnessStatement","InterviewTranscript",
+        "AudioTranscript",
         "ForensicReport","MedicalReport","EvidenceLog","Memo","CustodyForm"
     };
 
@@ -36,6 +37,7 @@ public class DocumentLayoutSmokeTests
             new PoliceReportLayout(),
             new WitnessStatementLayout(),
             new InterviewTranscriptLayout(),
+            new AudioTranscriptLayout(),
             new ForensicReportLayout(),
             new MedicalReportLayout(),
             new EvidenceLogLayout(),
@@ -81,6 +83,7 @@ public class DocumentLayoutSmokeTests
     [InlineData("PoliceReport")]
     [InlineData("WitnessStatement")]
     [InlineData("InterviewTranscript")]
+    [InlineData("AudioTranscript")]
     [InlineData("ForensicReport")]
     [InlineData("MedicalReport")]
     [InlineData("EvidenceLog")]

--- a/functions/CaseGen.Functions/Program.cs
+++ b/functions/CaseGen.Functions/Program.cs
@@ -36,6 +36,7 @@ builder.Services
     .AddScoped<IDocumentLayout, PoliceReportLayout>()
     .AddScoped<IDocumentLayout, WitnessStatementLayout>()
     .AddScoped<IDocumentLayout, InterviewTranscriptLayout>()
+    .AddScoped<IDocumentLayout, AudioTranscriptLayout>()
     .AddScoped<IDocumentLayout, ForensicReportLayout>()
     .AddScoped<IDocumentLayout, MedicalReportLayout>()
     .AddScoped<IDocumentLayout, EvidenceLogLayout>()
@@ -59,6 +60,7 @@ builder.Services
     .AddScoped<IEvidenceTemplate, ChatExportTemplate>()
     .AddScoped<IEvidenceTemplate, EmailExportTemplate>()
     .AddScoped<IEvidenceTemplate, AccessLogTemplate>()
+    .AddScoped<IEvidenceTemplate, AudioTranscriptTemplate>()
     .AddScoped<IEvidenceTemplateRegistry, EvidenceTemplateRegistry>()
     // LLM Provider — Azure OpenAI for production, Mock for local/dev without keys
     .AddScoped<ILLMProvider>(serviceProvider =>

--- a/functions/CaseGen.Functions/Services/CaseV2/AssetRenderingService.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/AssetRenderingService.cs
@@ -24,8 +24,9 @@ public class AssetRenderingReport
 /// Renders v2 assets to actual files next to the case JSON.
 /// - pdf/document  → QuestPDF via <see cref="IPdfRenderingService.GenerateTestPdfAsync"/>
 /// - photo/image   → image generation via <see cref="ILLMProvider.GenerateImageAsync"/>
-/// - audio/video   → placeholder .txt sidecar with the body/description
-/// - digital       → placeholder .txt sidecar with the body
+/// - digital       → PDF (digital-forensics export rendered via the doc renderer)
+/// Audio is intentionally NOT supported anymore — transcribed audio is
+/// produced as a `document` with layout = AudioTranscript.
 /// </summary>
 public class AssetRenderingService : IAssetRenderingService
 {
@@ -79,6 +80,10 @@ public class AssetRenderingService : IAssetRenderingService
                     imageTasks.Add(RenderImageAsync(caseId, assetsDir, a, report, ct));
                     break;
                 case "audio":
+                    // Audio is no longer planned; if the LLM ignores the prompt
+                    // and emits one anyway, fall back to a sidecar so the run
+                    // doesn't fail — but flag it.
+                    _logger.LogWarning("Legacy audio asset {Id} fell through — emitting sidecar; expected AudioTranscript document instead", a.Id);
                     RenderSidecar(assetsDir, a);
                     report.Skipped++;
                     break;

--- a/functions/CaseGen.Functions/Services/CaseV2/Rendering/DocumentChrome.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Rendering/DocumentChrome.cs
@@ -49,6 +49,11 @@ public enum ChromeKey
     RecordingRef,                    // "Recording Ref"
     Duration,                        // "Duration"
 
+    // Audio Transcript (recording transcribed from an audio file/dispatch tape)
+    AudioRecordingTranscript,        // AUDIO RECORDING TRANSCRIPT
+    RecordingDevice,                 // "Recording Device"
+    TranscribedBy,                   // "Transcribed by"
+
     // Forensic Report
     ForensicLetterhead,              // FORENSIC LABORATORY · CASE EXAMINATION REPORT
     EvidenceIntegrityVerified,       // EVIDENCE INTEGRITY VERIFIED
@@ -172,6 +177,9 @@ public static class DocumentChrome
             [ChromeKey.ConductedBy] = "Conducted by",
             [ChromeKey.RecordingRef] = "Recording Ref",
             [ChromeKey.Duration] = "Duration",
+            [ChromeKey.AudioRecordingTranscript] = "AUDIO RECORDING TRANSCRIPT",
+            [ChromeKey.RecordingDevice] = "Recording Device",
+            [ChromeKey.TranscribedBy] = "Transcribed by",
             [ChromeKey.ForensicLetterhead] = "FORENSIC LABORATORY · CASE EXAMINATION REPORT",
             [ChromeKey.EvidenceIntegrityVerified] = "EVIDENCE INTEGRITY VERIFIED",
             [ChromeKey.EvidenceIntegrityCompromised] = "EVIDENCE INTEGRITY COMPROMISED",
@@ -251,6 +259,9 @@ public static class DocumentChrome
             [ChromeKey.ConductedBy] = "Conduzida por",
             [ChromeKey.RecordingRef] = "Ref. da Gravação",
             [ChromeKey.Duration] = "Duração",
+            [ChromeKey.AudioRecordingTranscript] = "TRANSCRIÇÃO DE GRAVAÇÃO DE ÁUDIO",
+            [ChromeKey.RecordingDevice] = "Dispositivo de Gravação",
+            [ChromeKey.TranscribedBy] = "Transcrito por",
             [ChromeKey.ForensicLetterhead] = "LABORATÓRIO PERICIAL · LAUDO DE EXAME",
             [ChromeKey.EvidenceIntegrityVerified] = "INTEGRIDADE DA EVIDÊNCIA VERIFICADA",
             [ChromeKey.EvidenceIntegrityCompromised] = "INTEGRIDADE DA EVIDÊNCIA COMPROMETIDA",
@@ -330,6 +341,9 @@ public static class DocumentChrome
             [ChromeKey.ConductedBy] = "Realizada por",
             [ChromeKey.RecordingRef] = "Ref. de grabación",
             [ChromeKey.Duration] = "Duración",
+            [ChromeKey.AudioRecordingTranscript] = "TRANSCRIPCIÓN DE GRABACIÓN DE AUDIO",
+            [ChromeKey.RecordingDevice] = "Dispositivo de grabación",
+            [ChromeKey.TranscribedBy] = "Transcrito por",
             [ChromeKey.ForensicLetterhead] = "LABORATORIO FORENSE · INFORME DE EXAMEN",
             [ChromeKey.EvidenceIntegrityVerified] = "INTEGRIDAD DE LA EVIDENCIA VERIFICADA",
             [ChromeKey.EvidenceIntegrityCompromised] = "INTEGRIDAD DE LA EVIDENCIA COMPROMETIDA",
@@ -409,6 +423,9 @@ public static class DocumentChrome
             [ChromeKey.ConductedBy] = "Menée par",
             [ChromeKey.RecordingRef] = "Réf. d'enregistrement",
             [ChromeKey.Duration] = "Durée",
+            [ChromeKey.AudioRecordingTranscript] = "TRANSCRIPTION D'ENREGISTREMENT AUDIO",
+            [ChromeKey.RecordingDevice] = "Appareil d'enregistrement",
+            [ChromeKey.TranscribedBy] = "Transcrit par",
             [ChromeKey.ForensicLetterhead] = "LABORATOIRE DE POLICE SCIENTIFIQUE · RAPPORT D'EXAMEN",
             [ChromeKey.EvidenceIntegrityVerified] = "INTÉGRITÉ DES SCELLÉS VÉRIFIÉE",
             [ChromeKey.EvidenceIntegrityCompromised] = "INTÉGRITÉ DES SCELLÉS COMPROMISE",

--- a/functions/CaseGen.Functions/Services/CaseV2/Rendering/Layouts/AudioTranscriptLayout.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Rendering/Layouts/AudioTranscriptLayout.cs
@@ -1,0 +1,83 @@
+using CaseGen.Functions.Models.CaseV2;
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+
+namespace CaseGen.Functions.Services.CaseV2.Rendering.Layouts;
+
+/// <summary>
+/// Audio recording transcript: AUDIO RECORDING TRANSCRIPT banner, header
+/// strip with recording reference / duration / device / transcribed-by. Body
+/// is typically a <c>transcript</c> section, rendered through the shared
+/// <see cref="DocumentBlocks.RenderTranscript"/> helper. Distinct from
+/// <see cref="InterviewTranscriptLayout"/> (which is for interviews/oitivas)
+/// — this one is for transcribed recordings (dispatch tapes, voicemails,
+/// surveillance audio, witness phone calls, etc.).
+/// </summary>
+public sealed class AudioTranscriptLayout : IDocumentLayout
+{
+    public string Layout => "AudioTranscript";
+
+    public void Compose(IDocumentContainer container, EvidenceDocument doc)
+    {
+        container.Page(page =>
+        {
+            page.Size(PageSizes.A4);
+            page.Margin(36);
+            page.PageColor(Colors.White);
+            page.DefaultTextStyle(x => x.FontFamily(DocumentResources.FontFamilies.Sans).FontSize(10).LineHeight(1.35f));
+
+            page.Header().Element(h => BuildHeader(h, doc));
+            page.Content().PaddingTop(10).Column(col =>
+            {
+                DocumentBlocks.RenderSections(col, doc, (c, heading) =>
+                {
+                    c.Item().PaddingTop(6).PaddingBottom(3).Text(heading.ToUpperInvariant())
+                        .FontSize(9.5f).Bold().FontColor("#1F3864").LetterSpacing(0.05f);
+                    c.Item().PaddingBottom(3).LineHorizontal(0.4f).LineColor("#1F3864");
+                });
+                if (doc.Signature is not null)
+                    col.Item().PaddingTop(20).Element(c => DocumentBlocks.RenderSignature(c, doc.Signature, ChromeKey.SignatureOfficer, doc.Language));
+            });
+            page.Footer().Element(f => DocumentBlocks.StandardFooter(f, doc));
+        });
+    }
+
+    private static void BuildHeader(IContainer container, EvidenceDocument doc)
+    {
+        container.Column(col =>
+        {
+            col.Item().Background("#1A365D").Padding(6).Row(r =>
+            {
+                r.ConstantItem(36).Height(36).Image(DocumentResources.BrasaoPng).FitArea();
+                r.RelativeItem().PaddingLeft(8).Column(c =>
+                {
+                    c.Item().Text(DocumentChrome.Get(ChromeKey.AudioRecordingTranscript, doc.Language))
+                        .FontSize(10).Bold().FontColor(Colors.White).LetterSpacing(0.15f);
+                    c.Item().Text(doc.Title).FontSize(13).Bold().FontColor(Colors.White);
+                    if (!string.IsNullOrEmpty(doc.Subtitle))
+                        c.Item().Text(doc.Subtitle).FontSize(9).FontColor("#C7D2FE").Italic();
+                });
+            });
+
+            if (doc.Header.Count > 0)
+            {
+                col.Item().Background("#EEF2FF").Padding(6).Row(r =>
+                {
+                    foreach (var kv in doc.Header.Take(4))
+                    {
+                        r.RelativeItem().Column(c =>
+                        {
+                            c.Item().Text(kv.Label).FontSize(7.5f).Bold().FontColor("#1A365D").LetterSpacing(0.05f);
+                            c.Item().Text(kv.Value).FontSize(9);
+                        });
+                    }
+                });
+            }
+
+            col.Item().Background("#FBE5E5").Padding(2).AlignCenter()
+                .Text(DocumentChrome.Get(ChromeKey.Confidential, doc.Language).ToUpperInvariant())
+                .FontSize(7).FontColor("#B71C1C").Bold().LetterSpacing(0.05f);
+        });
+    }
+}

--- a/functions/CaseGen.Functions/Services/CaseV2/Tasks/AssetTasks.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Tasks/AssetTasks.cs
@@ -24,7 +24,7 @@ public class AssetPlanTask
           "items":{"type":"object","required":["id","type","title","role","visibility"],
             "properties":{
               "id":{"type":"string","pattern":"^asset\\.[a-z0-9_]+$"},
-              "type":{"type":"string","enum":["photo","pdf","document","audio","digital"]},
+              "type":{"type":"string","enum":["photo","pdf","document","digital"]},
               "visibility":{"type":"string","enum":["initial","hidden"]}
             }}}
       }
@@ -36,16 +36,16 @@ public class AssetPlanTask
         var system = @"You are planning the **initial evidence assets** a detective collects on day one of an investigation.
 List 4-10 distinct assets. Each has:
 - id (pattern `asset.<snake>`)
-- type — one of these EXACT values (do NOT use anything else, especially not `video` or `image`):
+- type — one of these EXACT values (do NOT use anything else, especially not `video`, `image`, or `audio`):
     * `photo`    — a single still image of a scene / object / location
     * `pdf`      — a PDF report or evidence document (will be rendered with QuestPDF)
-    * `document` — same renderer as `pdf` (alias for narrative purposes)
-    * `audio`    — an audio recording (transcript stored in sidecar, audio TTS deferred)
+    * `document` — same renderer as `pdf` (alias for narrative purposes). USE THIS for transcribed audio (dispatch tapes, 911 calls, voicemails, surveillance audio) — set layout = `AudioTranscript` in the later step.
     * `digital`  — a digital-forensics export (call logs, POS data, sensor log, file listing). Will be rendered as a PDF report.
 - a short title
 - a ONE-LINE role explaining how it fits the case
 - `visibility` = `initial` (all assets here are initial; result PDFs from forensics come later).
 
+Do NOT plan raw audio or video media — there is no audio/video player. Anything an investigator would normally listen to (911 call, dispatch tape, voicemail, intercom audio) is delivered as a TRANSCRIBED document (`document` type, AudioTranscript layout).
 Do NOT write descriptions or metadata — that comes in a later step. Pick assets that make sense given the case draft.";
         var user = $@"CASE DRAFT (read-only):
 {draft.ToSummaryJson()}
@@ -97,18 +97,17 @@ public class AssetCardTask
                 ("Set `bodyDoc` to a structured EvidenceDocument (see schema in this prompt). PICK a `layout` from the family below based on what the asset represents (be precise — the renderer styles each family differently):\n" +
                  "  · `PoliceReport`        — initial / supplemental police reports, first-responder narratives (brasão letterhead, §1/§2 numbered sections).\n" +
                  "  · `WitnessStatement`    — sworn statements taken from a witness (STATEMENT OF block, oath, double signature).\n" +
-                 "  · `InterviewTranscript` — interviews / interrogations. Use a `transcript` section.\n" +
+                 "  · `InterviewTranscript` — interviews / interrogations conducted face-to-face by the police. Use a `transcript` section.\n" +
+                 "  · `AudioTranscript`     — transcribed audio recordings (911 / dispatch tapes, voicemails, intercom audio, surveillance recordings). Header should include `Recording Ref`, `Duration`, `Recording Device`, `Transcribed by`. Body is a `transcript` section with {timestamp, speaker, text}.\n" +
                  "  · `ForensicReport`      — lab examination reports (CCTV correlation, video enhancement, fingerprint analysis, ballistics, DNA, toxicology). Use sections Items Submitted / Methodology / Findings / Conclusions / Limitations.\n" +
                  "  · `MedicalReport`       — preliminary ME reports, autopsy summaries, urgent-care visit records. Sections History / External Examination / Findings / Cause / Disposition.\n" +
                  "  · `EvidenceLog`         — evidence log / chain of custody. ALWAYS include a `table` with columns Item, Description, Collected By, Time, Location, Container, Seal.\n" +
                  "  · `Memo`                — internal memorandums, records preservation holds, tasking memos, admin summaries, compliance briefs. Header[] MUST include TO, FROM, DATE, RE.\n" +
                  "  · `CustodyForm`         — key-control sign-out, cash count, drop-safe audit, case briefing. Header[] has the form fields. Include a signatures section.\n" +
                  "  · `GeneralReport`       — only if NONE of the above apply.\n" +
-                 "Use `narrative` for prose, `transcript` for Q/A, `keyValue` for header-style facts (date, location, officer), `table` for tabulated data, `callout` for highlighted notes. Anchor every date/time to the case timeline (incidentDate / openedAt).", true),
+                 "Use `narrative` for prose, `transcript` for Q/A or transcribed audio, `keyValue` for header-style facts (date, location, officer), `table` for tabulated data, `callout` for highlighted notes. Anchor every date/time to the case timeline (incidentDate / openedAt).", true),
             "photo" =>
                 ("Set `body` to a vivid image prompt that an image model can render (lighting, composition, framing, mood, visible details). Leave `bodyDoc` null.", false),
-            "audio" =>
-                ("Set `body` to a transcript + descriptive note (stored as sidecar, TTS deferred). Leave `bodyDoc` null.", false),
             "digital" =>
                 ("Set `bodyDoc` to a structured EvidenceDocument. CHOOSE one of these recognised digital layouts so a specialised template can enrich the output:\n" +
                  "  · `CallLog`         — telecom CDRs. Table columns: Timestamp, Direction, Other Party, Duration, Notes.\n" +

--- a/functions/CaseGen.Functions/Services/CaseV2/Templates/AudioTranscriptTemplate.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Templates/AudioTranscriptTemplate.cs
@@ -1,0 +1,37 @@
+using CaseGen.Functions.Models.CaseV2;
+using static CaseGen.Functions.Services.CaseV2.Templates.TemplateHelpers;
+
+namespace CaseGen.Functions.Services.CaseV2.Templates;
+
+/// <summary>
+/// Audio recording transcript. Enriches the header with recording metadata
+/// (file ref, duration, device, transcribed by) when the LLM omits them, and
+/// ensures the body has at least one usable section. Pairs with
+/// <see cref="Rendering.Layouts.AudioTranscriptLayout"/>.
+/// </summary>
+public class AudioTranscriptTemplate : IEvidenceTemplate
+{
+    public string Layout => "AudioTranscript";
+
+    public EvidenceDocument Enrich(EvidenceDocument doc)
+    {
+        EnsureHeader(doc, "Document Type", "Audio Recording Transcript");
+        EnsureHeader(doc, "Recording Ref", doc.Header.FirstOrDefault(h =>
+            h.Label.Contains("recording", StringComparison.OrdinalIgnoreCase))?.Value
+            ?? "REC-" + Guid.NewGuid().ToString("N").Substring(0, 8).ToUpperInvariant());
+        EnsureHeader(doc, "Duration", doc.Header.FirstOrDefault(h =>
+            h.Label.Contains("duration", StringComparison.OrdinalIgnoreCase))?.Value
+            ?? "—");
+
+        // If the LLM gave us only narrative prose, the layout still renders it
+        // fine; we only warn (via callout) when the section list is completely
+        // empty so a downstream reviewer sees the gap.
+        if (doc.Sections.Count == 0)
+        {
+            AppendSection(doc, CalloutSection(
+                "No transcript content was produced. Re-run generation for this asset.",
+                "Missing Transcript"));
+        }
+        return doc;
+    }
+}


### PR DESCRIPTION
## Problem
CaseGen still emits `audio` assets (e.g. `security_radio_recording.mp3.txt`, `curator_last_call_audio.mp3.txt`). The FileViewer in the frontend has no audio player, so those blobs land in storage as inert `.mp3.txt` sidecars — the player never gets anything actionable.

## Fix
Drop `audio` from the generator's vocabulary. Anything an investigator would normally listen to (911 / dispatch tapes, voicemails, intercom audio, surveillance recordings) is now produced as a transcribed document using a new `AudioTranscript` layout.

## Changes
### New
- `Services/CaseV2/Rendering/Layouts/AudioTranscriptLayout.cs` — *AUDIO RECORDING TRANSCRIPT* banner, recording-metadata strip (Recording Ref / Duration / Device / Transcribed By), transcript body, chain-of-custody footer.
- `Services/CaseV2/Templates/AudioTranscriptTemplate.cs` — backfills missing recording-metadata header fields and warns via a callout when the body is empty.

### Updated
- `DocumentChrome.cs` — 3 new `ChromeKey`s (`AudioRecordingTranscript`, `RecordingDevice`, `TranscribedBy`) localized across the 4 supported languages (en-US / pt-BR / es-ES / fr-FR).
- `AssetTasks.cs` (`AssetPlan` schema/prompt) — dropped `audio` from the type enum; added an explicit instruction ""do NOT plan raw audio or video media — there is no audio/video player"" and pointed the LLM to `document` + `AudioTranscript` layout.
- `AssetTasks.cs` (`AssetCard` prompt) — dropped the `audio` body branch; added `AudioTranscript` to the recognised pdf/document layout family.
- `AssetRenderingService.cs` — defensive sidecar branch kept for legacy/edge cases (logs a warning if the LLM still emits audio).
- `Program.cs` — registered the new layout + template with DI.
- `DocumentLayoutSmokeTests.cs` — added `AudioTranscript` to `AllLayouts`, `BuildRegistry()` and the per-layout PDF-render theory.

## Notes
- `case.v2.schema.json` still allows `audio` for backward-compat with legacy cases.
- The two cases I deleted from blob storage (`case_20260516_100535` and `case_20260515_193838`) won't regenerate with audio sidecars once this lands.

## Tests / Build
- `dotnet build` clean.
- `dotnet test` — **20/20** in `CaseGen.Functions.Tests` (the new AudioTranscript layout is exercised in the smoke theory).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>