### PR TITLE
feat: iterative refine + red-team loop (up to 3 passes)

### DIFF
--- a/frontend/src/pages/CaseGenerationPage.tsx
+++ b/frontend/src/pages/CaseGenerationPage.tsx
@@ -18,6 +18,7 @@ const PHASES: { id: string; label: string }[] = [
   { id: 'autoFixSchema',                label: 'Auto-fix schema (deterministic, conditional)' },
   { id: 'redTeamAndSolver',             label: 'Red-team + solver' },
   { id: 'refineCase',                   label: 'Refine (LLM, conditional)' },
+  { id: 'redTeamRerun',                 label: 'Red-team rerun (conditional)' },
   { id: 'renderAssets',                 label: 'Render PDFs + images' },
   { id: 'publishToBlob',                label: 'Publish to blob storage' }
 ]
@@ -421,12 +422,29 @@ const CaseGenerationPage = () => {
                 <Stat><StatLbl>Images rendered</StatLbl><StatVal>{status.result.AssetsRenderedImages}</StatVal></Stat>
                 <Stat><StatLbl>Blobs published</StatLbl><StatVal>{status.result.BlobsPublished}</StatVal></Stat>
                 <Stat><StatLbl>Auto-fixes applied</StatLbl><StatVal>{status.result.AutoFixesApplied?.length ?? 0}</StatVal></Stat>
-                <Stat><StatLbl>Refine attempted</StatLbl><StatVal>{status.result.RefineAttempted ? 'yes' : 'no'}</StatVal></Stat>
+                <Stat>
+                  <StatLbl>Refine attempted</StatLbl>
+                  <StatVal>
+                    {status.result.RefineAttempted ? 'yes' : 'no'}
+                    {(status.result.RefineIterations ?? 0) > 0 && (
+                      <span style={{ color: 'rgba(148, 197, 255, 0.7)', fontSize: '0.8rem', marginLeft: '0.4rem' }}>
+                        ({status.result.RefineIterations} iter)
+                      </span>
+                    )}
+                  </StatVal>
+                </Stat>
                 <Stat>
                   <StatLbl>Red-team verdict</StatLbl>
                   <StatVal style={{ fontSize: '0.95rem' }}>
                     {status.result.RedTeamVerdict ?? '—'}
-                    {status.result.RedTeamRerun && status.result.RedTeamVerdictInitial && (
+                    {(status.result.RedTeamVerdictTrajectory?.length ?? 0) > 1 && (
+                      <span style={{ color: 'rgba(148, 197, 255, 0.7)', fontSize: '0.8rem', marginLeft: '0.4rem' }}>
+                        ({status.result.RedTeamVerdictTrajectory!.join(' → ')})
+                      </span>
+                    )}
+                    {(status.result.RedTeamVerdictTrajectory?.length ?? 0) <= 1
+                      && status.result.RedTeamRerun
+                      && status.result.RedTeamVerdictInitial && (
                       <span style={{ color: 'rgba(148, 197, 255, 0.7)', fontSize: '0.8rem', marginLeft: '0.4rem' }}>
                         (was {status.result.RedTeamVerdictInitial})
                       </span>

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -388,8 +388,10 @@ export interface GenerateCaseStatus {
     RefineAttempted?: boolean
     RefineErrorsBefore?: number
     RefineErrorsAfter?: number
+    RefineIterations?: number
     RedTeamVerdict?: string | null
     RedTeamVerdictInitial?: string | null
+    RedTeamVerdictTrajectory?: string[] | null
     RedTeamRerun?: boolean
   } | null
 }

--- a/functions/CaseGen.Functions/Functions/CaseV2/CaseV2GenerationOrchestrator.cs
+++ b/functions/CaseGen.Functions/Functions/CaseV2/CaseV2GenerationOrchestrator.cs
@@ -74,8 +74,10 @@ public record CaseV2JobResult(
     bool RefineAttempted,
     int RefineErrorsBefore,
     int RefineErrorsAfter,
+    int RefineIterations,
     string? RedTeamVerdict,
     string? RedTeamVerdictInitial,
+    List<string> RedTeamVerdictTrajectory,
     bool RedTeamRerun);
 
 /// <summary>
@@ -143,8 +145,10 @@ public class CaseV2GenerateActivity
                 RefineAttempted: response.RefineAttempted,
                 RefineErrorsBefore: response.RefineErrorsBefore,
                 RefineErrorsAfter: response.RefineErrorsAfter,
+                RefineIterations: response.RefineIterations,
                 RedTeamVerdict: response.RedTeam?.Verdict,
                 RedTeamVerdictInitial: response.RedTeamInitial?.Verdict,
+                RedTeamVerdictTrajectory: response.RedTeamVerdictTrajectory,
                 RedTeamRerun: response.RedTeamRerun);
         }
         catch (Exception ex)

--- a/functions/CaseGen.Functions/Models/CaseV2/CaseV2GenerationModels.cs
+++ b/functions/CaseGen.Functions/Models/CaseV2/CaseV2GenerationModels.cs
@@ -34,10 +34,12 @@ public class GenerateCaseV2Response
     public bool RefineAttempted { get; set; }
     public int RefineErrorsBefore { get; set; }
     public int RefineErrorsAfter { get; set; }
+    public int RefineIterations { get; set; }
     public bool RedTeamRerun { get; set; }
     public Services.CaseV2.ConsistencyReport? Consistency { get; set; }
     public Services.CaseV2.Tasks.RedTeamTask.Report? RedTeam { get; set; }
     public Services.CaseV2.Tasks.RedTeamTask.Report? RedTeamInitial { get; set; }
+    public List<string> RedTeamVerdictTrajectory { get; set; } = new();
     public Services.CaseV2.Tasks.SolverTask.SolverResult? Solver { get; set; }
 }
 

--- a/functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs
@@ -209,9 +209,18 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
         // === Phase 11: assemble + JSON-schema validate (structural)
         var assembled = Assemble(draft);
         var json = assembled.ToJsonString(JsonOpts);
-        var errors = Validate(json);
-        if (consistencyReport is not null)
-            errors.AddRange(consistencyReport.Errors);
+
+        // Local helper: schema + consistency errors combined. Refine accepts the
+        // refined JSON based on this combined count, so consistency findings don't
+        // silently get erased when refine fixes schema issues.
+        List<string> ValidateAll(string j)
+        {
+            var all = Validate(j);
+            if (consistencyReport is not null) all.AddRange(consistencyReport.Errors);
+            return all;
+        }
+
+        var errors = ValidateAll(json);
 
         // === Phase 11b: deterministic auto-fix for common LLM ID-format slips
         //     (e.g. `asset_xxx` → `asset.xxx`). Runs only when there are errors.
@@ -224,8 +233,7 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
                 if (autoFixes.Count > 0)
                 {
                     json = assembled.ToJsonString(JsonOpts);
-                    var rev = Validate(json);
-                    if (consistencyReport is not null) rev.AddRange(consistencyReport.Errors);
+                    var rev = ValidateAll(json);
                     _logger.LogInformation("AutoFixer cleared {Before}→{After} validation errors",
                         errors.Count, rev.Count);
                     errors = rev;
@@ -236,75 +244,166 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
 
         // === Phase 12: red-team + solver (semantic validation) — run in parallel
         // Always run these — even on schema-error cases the reports help diagnose what went wrong.
+        // Both the initial red-team pass and any reruns use the assembled JSON path so the
+        // input to the LLM is identical across iterations.
         Tasks.RedTeamTask.Report? redTeam = null;
         Tasks.SolverTask.SolverResult? solver = null;
         await Stage("redTeamAndSolver", async () =>
         {
-            var rt = new Tasks.RedTeamTask(_llm, _logger).RunAsync(draft, json, ct);
+            var rt = new Tasks.RedTeamTask(_llm, _logger).RunOnAssembledAsync(json, ct);
             var sv = new Tasks.SolverTask(_llm, _logger).RunAsync(draft, ct);
             redTeam = await rt;
             solver = await sv;
         });
 
-        // === Phase 12b: refine via LLM if schema errors persist OR red-team rejected.
-        var refineAttempted = false;
-        var redTeamRerun = false;
-        Tasks.RedTeamTask.Report? redTeamInitial = null;
+        // === Phase 12b: iterative refine + red-team loop.
+        // Goal: drive the case toward an `ok` verdict without schema errors.
+        // Up to N refine attempts; each accepted refine triggers a fresh red-team audit.
+        // Stops early on success, plateau, or regression (with revert).
+        var maxRefineIterations = int.TryParse(_config["CaseGenV2:RefineMaxIterations"], out var cfgN) && cfgN > 0
+            ? cfgN : 3;
+        var refineIterations = 0;
         var refineErrorsBefore = errors.Count;
-        var highFindings = redTeam?.Findings.Where(f =>
-            string.Equals(f.Severity, "high", StringComparison.OrdinalIgnoreCase)).ToList()
-            ?? new List<Tasks.RedTeamTask.Finding>();
-        var shouldRefine = errors.Count > 0
-            || (string.Equals(redTeam?.Verdict, "reject", StringComparison.OrdinalIgnoreCase) && highFindings.Count > 0);
+        Tasks.RedTeamTask.Report? redTeamInitial = null;
+        var verdictTrajectory = new List<string>();
+        if (!string.IsNullOrEmpty(redTeam?.Verdict))
+            verdictTrajectory.Add(redTeam!.Verdict);
 
-        if (shouldRefine)
+        static int VerdictRank(string? v) => (v?.ToLowerInvariant()) switch
         {
+            "ok" => 0,
+            "needs_review" => 1,
+            _ => 2 // reject or unknown
+        };
+
+        // Severity-weighted score: high counts much more than medium, medium much
+        // more than low. Used for plateau / regression comparisons so swapping
+        // 3 medium findings for 1 high finding registers as a regression.
+        static int FindingsScore(IEnumerable<Tasks.RedTeamTask.Finding>? findings)
+        {
+            if (findings is null) return 0;
+            var score = 0;
+            foreach (var f in findings)
+            {
+                score += (f.Severity?.ToLowerInvariant()) switch
+                {
+                    "high" => 100,
+                    "medium" => 10,
+                    _ => 1
+                };
+            }
+            return score;
+        }
+
+        while (refineIterations < maxRefineIterations)
+        {
+            // Refine if schema errors remain OR if red-team verdict is not `ok` AND has at least one non-low finding.
+            var actionableFindings = redTeam?.Findings.Where(f =>
+                !string.Equals(f.Severity, "low", StringComparison.OrdinalIgnoreCase)).ToList()
+                ?? new List<Tasks.RedTeamTask.Finding>();
+            var verdictLower = redTeam?.Verdict?.ToLowerInvariant();
+            var shouldRefine = errors.Count > 0
+                || ((verdictLower == "reject" || verdictLower == "needs_review") && actionableFindings.Count > 0);
+
+            if (!shouldRefine) break;
+
+            refineIterations++;
+            if (redTeamInitial is null) redTeamInitial = redTeam;
+
+            // Snapshot for potential revert on regression / plateau (semantic-only).
+            var prevJson = json;
+            var prevErrors = errors;
+            var prevRedTeam = redTeam;
+            var prevFindingScore = FindingsScore(redTeam?.Findings);
+            var prevRank = VerdictRank(redTeam?.Verdict);
+            var prevHadSchemaErrors = errors.Count > 0;
+            var refinedAccepted = false;
+
             await Stage("refineCase", async () =>
             {
-                refineAttempted = true;
                 var result = await new Tasks.RefineCaseTask(_llm, _logger)
-                    .RunAsync(json, errors, highFindings, _v2SchemaJson, ct);
+                    .RunAsync(json, errors, actionableFindings, _v2SchemaJson, ct);
 
                 if (result.Succeeded)
                 {
                     var refined = result.RefinedJson!;
-                    var revalidated = Validate(refined);
+                    var revalidated = ValidateAll(refined);
                     if (revalidated.Count < errors.Count
                         || (errors.Count == 0 && !string.Equals(refined, json, StringComparison.Ordinal)))
                     {
-                        _logger.LogInformation("Refine improved errors {Before}→{After} — accepting refined JSON",
-                            errors.Count, revalidated.Count);
+                        _logger.LogInformation("Refine iteration {N} accepted (validation errors {Before}→{After})",
+                            refineIterations, errors.Count, revalidated.Count);
                         json = refined;
                         errors = revalidated;
+                        refinedAccepted = true;
                     }
                     else
                     {
-                        _logger.LogWarning("Refine did NOT reduce error count ({Before}→{After}) — keeping pre-refine JSON",
-                            errors.Count, revalidated.Count);
+                        _logger.LogWarning("Refine iteration {N} did NOT improve — stopping loop", refineIterations);
                     }
                 }
                 else
                 {
-                    _logger.LogWarning("RefineCaseTask returned no document: {Error}", result.Error);
+                    _logger.LogWarning("RefineCaseTask iteration {N} returned no document: {Error}",
+                        refineIterations, result.Error);
                 }
             });
 
-            // === Phase 12c: re-run RedTeam on the refined JSON so the published verdict
-            // reflects whether refine actually addressed the findings. Skip when refine
-            // did not improve anything (initial verdict is still accurate).
-            if (refineAttempted && errors.Count == 0)
+            if (!refinedAccepted) break;
+
+            // Re-run RedTeam only once the schema is clean; otherwise spend the next iteration
+            // on fixing the remaining schema errors first.
+            if (errors.Count > 0) continue;
+
+            await Stage("redTeamRerun", async () =>
             {
-                await Stage("redTeamRerun", async () =>
+                redTeam = await new Tasks.RedTeamTask(_llm, _logger).RunOnAssembledAsync(json, ct);
+                verdictTrajectory.Add(redTeam.Verdict);
+                _logger.LogInformation("RedTeam rerun {N}: verdict={Verdict} findings={Count}",
+                    refineIterations, redTeam.Verdict, redTeam.Findings.Count);
+            });
+
+            var newRank = VerdictRank(redTeam?.Verdict);
+            var newFindingScore = FindingsScore(redTeam?.Findings);
+
+            // Regression → revert and stop.
+            if (newRank > prevRank || (newRank == prevRank && newFindingScore > prevFindingScore))
+            {
+                _logger.LogWarning("Refine iteration {N} regressed (verdict {PrevV}→{NewV}, score {PrevS}→{NewS}) — reverting",
+                    refineIterations, prevRedTeam?.Verdict, redTeam?.Verdict, prevFindingScore, newFindingScore);
+                json = prevJson;
+                errors = prevErrors;
+                redTeam = prevRedTeam;
+                if (verdictTrajectory.Count > 0)
+                    verdictTrajectory[verdictTrajectory.Count - 1] += " (reverted)";
+                break;
+            }
+
+            // Success.
+            if (newRank == 0) break;
+
+            // Plateau — verdict didn't improve and severity-weighted score didn't decrease.
+            if (newRank >= prevRank && newFindingScore >= prevFindingScore)
+            {
+                _logger.LogInformation("Refine iteration {N} plateaued — stopping loop", refineIterations);
+                // For semantic-only iterations (no pre-existing schema errors), revert to
+                // the snapshot since the LLM edits brought no measurable benefit.
+                if (!prevHadSchemaErrors)
                 {
-                    redTeamInitial = redTeam;
-                    var rerun = await new Tasks.RedTeamTask(_llm, _logger).RunOnAssembledAsync(json, ct);
-                    redTeam = rerun;
-                    redTeamRerun = true;
-                    _logger.LogInformation("RedTeam rerun after refine: {Initial} → {Final}",
-                        redTeamInitial?.Verdict, rerun.Verdict);
-                });
+                    json = prevJson;
+                    errors = prevErrors;
+                    redTeam = prevRedTeam;
+                    if (verdictTrajectory.Count > 0)
+                        verdictTrajectory[verdictTrajectory.Count - 1] += " (no gain)";
+                }
+                break;
             }
         }
+
+        var refineAttempted = refineIterations > 0;
+        var redTeamRerun = (redTeamInitial is not null
+                && !string.Equals(redTeamInitial.Verdict, redTeam?.Verdict, StringComparison.OrdinalIgnoreCase))
+            || verdictTrajectory.Count > 1;
 
         // === Phase 13: persist + render assets
         var outputPath = string.Empty;
@@ -354,9 +453,11 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
             RefineAttempted = refineAttempted,
             RefineErrorsBefore = refineErrorsBefore,
             RefineErrorsAfter = errors.Count,
+            RefineIterations = refineIterations,
             RedTeamRerun = redTeamRerun,
             RedTeam = redTeam,
             RedTeamInitial = redTeamInitial,
+            RedTeamVerdictTrajectory = verdictTrajectory,
             Solver = solver,
             Consistency = consistencyReport
         };
@@ -633,6 +734,12 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
     {
         var sw = Stopwatch.StartNew();
         try { await body(); }
-        finally { sink[name] = sw.Elapsed.TotalMilliseconds; }
+        finally
+        {
+            // Accumulate latency so stages that fire multiple times during the
+            // refine loop (refineCase, redTeamRerun) report total time spent.
+            sink.TryGetValue(name, out var prev);
+            sink[name] = prev + sw.Elapsed.TotalMilliseconds;
+        }
     }
 }

--- a/functions/CaseGen.Functions/Services/CaseV2/Tasks/RefineCaseTask.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Tasks/RefineCaseTask.cs
@@ -35,7 +35,7 @@ public class RefineCaseTask
     public async Task<Result> RunAsync(
         string currentJson,
         IReadOnlyList<string> validationErrors,
-        IReadOnlyList<RedTeamTask.Finding> highFindings,
+        IReadOnlyList<RedTeamTask.Finding> findings,
         string schemaJson,
         CancellationToken ct)
     {
@@ -43,9 +43,20 @@ public class RefineCaseTask
             ? "(no schema errors)"
             : string.Join("\n", validationErrors.Select(e => "- " + e));
 
-        var findingBlock = highFindings.Count == 0
+        var highFindings = findings.Where(f =>
+            string.Equals(f.Severity, "high", StringComparison.OrdinalIgnoreCase)).ToList();
+        var mediumFindings = findings.Where(f =>
+            string.Equals(f.Severity, "medium", StringComparison.OrdinalIgnoreCase)).ToList();
+
+        var highBlock = highFindings.Count == 0
             ? "(no high-severity red-team findings)"
             : string.Join("\n", highFindings.Select(f =>
+                $"- area={f.Area} severity={f.Severity} issue={f.Issue}" +
+                (string.IsNullOrEmpty(f.Suggestion) ? "" : $" suggestion={f.Suggestion}")));
+
+        var mediumBlock = mediumFindings.Count == 0
+            ? "(no medium-severity red-team findings)"
+            : string.Join("\n", mediumFindings.Select(f =>
                 $"- area={f.Area} severity={f.Severity} issue={f.Issue}" +
                 (string.IsNullOrEmpty(f.Suggestion) ? "" : $" suggestion={f.Suggestion}")));
 
@@ -53,8 +64,9 @@ public class RefineCaseTask
 
 1. Satisfies every JSON-Schema constraint listed in the supplied schema (especially id-pattern constraints like `^asset\.[a-z0-9_]+$`, `^tevt\.[a-z0-9_]+$`, etc.).
 2. Addresses every high-severity red-team finding listed.
-3. Preserves the rest of the case as faithfully as possible — DO NOT rewrite plot, suspects, timeline, motive, evidence, or solution unless explicitly required to fix a flagged issue. Keep IDs stable when fixing referential issues; if an ID must change, also update every reference to it.
-4. Emit ONLY the corrected JSON document — no commentary, no markdown fences. The top-level must be an object matching the v2 case schema.
+3. Also addresses medium-severity findings whenever doing so does not require restructuring the case (e.g. sharpening a motive, tightening an alibi, clarifying a forensic conclusion).
+4. Preserves the rest of the case as faithfully as possible — DO NOT rewrite plot, suspects, timeline, motive, evidence, or solution unless explicitly required to fix a flagged issue. Keep IDs stable when fixing referential issues; if an ID must change, also update every reference to it.
+5. Emit ONLY the corrected JSON document — no commentary, no markdown fences. The top-level must be an object matching the v2 case schema.
 
 Be surgical. If the only complaint is malformed IDs, just fix the IDs (and their references). If a finding says ""smoking gun too weak"", you may add a sentence to the relevant ConclusionText or sharpen a forensic outcome, but don't restructure the case.";
 
@@ -65,7 +77,10 @@ Be surgical. If the only complaint is malformed IDs, just fix the IDs (and their
 {errorBlock}
 
 === HIGH-SEVERITY RED-TEAM FINDINGS ===
-{findingBlock}
+{highBlock}
+
+=== MEDIUM-SEVERITY RED-TEAM FINDINGS ===
+{mediumBlock}
 
 Emit the corrected case.json as a single JSON object.";
 


### PR DESCRIPTION
## Why

Following PR #154, the red-team rerun showed exactly what the user expected: a case that went ``reject`` → ``needs_review`` after refine. But the loop stopped there — even though the refined case still had medium-severity findings the LLM could plausibly address in another pass. This PR turns the single-shot refine into a **bounded loop**.

## What changed

### Loop semantics (`CaseV2GeneratorService`)

- Up to ``CaseGenV2:RefineMaxIterations`` iterations (default **3**).
- Each iteration: ``Refine`` → (if schema clean) ``RedTeam rerun`` → decide whether to continue.
- **Stop conditions**:
  - Verdict reaches ``ok``.
  - Refine produces no improvement at all.
  - **Regression**: new verdict rank worsens, or severity-weighted finding score increases. Revert to pre-iteration snapshot.
  - **Plateau** (no measurable gain). On semantic-only iterations (no pre-existing schema errors) we also revert so we don't keep arbitrary LLM edits.

### Quality fixes (caught by rubber-duck pass before commit)

1. **Consistency-error preservation**: a new ``ValidateAll`` helper combines schema + consistency errors so refine acceptance no longer silently drops consistency findings.
2. **Severity-weighted score** (``high=100, medium=10, low=1``): swapping 3 medium findings for 1 high finding now registers as a regression instead of an improvement.
3. **Apples-to-apples red-team input**: the initial red-team call now also uses ``RunOnAssembledAsync`` so iteration 0 and iteration N feed the auditor identical input.
4. **Medium findings included in refine input**: ``RefineCaseTask`` now receives both high- and medium-severity findings so ``needs_review`` cases can actually be lifted toward ``ok``.

### UI surface (`CaseGenerationPage`)

- ``Refine attempted: yes (2 iter)``
- ``Red-team verdict: ok (reject → needs_review → ok)`` (trajectory rendered when there's more than one verdict). ``(reverted)`` / ``(no gain)`` suffixes appear on aborted iterations.
- New ``Red-team rerun (conditional)`` phase row.
- Stage latency now accumulates across iterations.

### Config

- New env var ``CaseGenV2__RefineMaxIterations`` (override the default of 3). Set to ``1`` to get the previous single-shot behavior.

## Tests

- ``dotnet test``: 20/20 pass
- ``npm test``: 25/25 pass
- ``npm run build``: clean

## Cost note

Worst case: 3× (refine ~50s + redteam ~10s) ≈ +2 min and ~30K tokens above baseline. Loop terminates early on success / plateau, so most cases will spend less than that.
