### PR TITLE
Add area-targeted refine playbooks for Timeline/SmokingGun/Questions

### DIFF
--- a/functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs
@@ -339,7 +339,8 @@ public class CaseV2GeneratorService : ICaseV2GeneratorService
             await Stage("refineCase", async () =>
             {
                 var result = await new Tasks.RefineCaseTask(_llm, _logger)
-                    .RunAsync(json, errors, actionableFindings, _v2SchemaJson, ct);
+                    .RunAsync(json, errors, actionableFindings, _v2SchemaJson, ct,
+                        difficulty: draft.Metadata.Difficulty);
 
                 if (result.Succeeded)
                 {

--- a/functions/CaseGen.Functions/Services/CaseV2/Tasks/RefineCaseTask.cs
+++ b/functions/CaseGen.Functions/Services/CaseV2/Tasks/RefineCaseTask.cs
@@ -37,7 +37,8 @@ public class RefineCaseTask
         IReadOnlyList<string> validationErrors,
         IReadOnlyList<RedTeamTask.Finding> findings,
         string schemaJson,
-        CancellationToken ct)
+        CancellationToken ct,
+        string? difficulty = null)
     {
         var errorBlock = validationErrors.Count == 0
             ? "(no schema errors)"
@@ -60,6 +61,9 @@ public class RefineCaseTask
                 $"- area={f.Area} severity={f.Severity} issue={f.Issue}" +
                 (string.IsNullOrEmpty(f.Suggestion) ? "" : $" suggestion={f.Suggestion}")));
 
+        var areaGuidance = BuildAreaGuidance(findings);
+        var isRookie = string.Equals(difficulty, "Rookie", StringComparison.OrdinalIgnoreCase);
+
         var system = @"You are the **refine agent** for an interactive detective case. You receive a case.json document that failed validation or red-team review, plus the list of problems. Your job is to emit a corrected case.json that:
 
 1. Satisfies every JSON-Schema constraint listed in the supplied schema (especially id-pattern constraints like `^asset\.[a-z0-9_]+$`, `^tevt\.[a-z0-9_]+$`, etc.).
@@ -69,6 +73,23 @@ public class RefineCaseTask
 5. Emit ONLY the corrected JSON document — no commentary, no markdown fences. The top-level must be an object matching the v2 case schema.
 
 Be surgical. If the only complaint is malformed IDs, just fix the IDs (and their references). If a finding says ""smoking gun too weak"", you may add a sentence to the relevant ConclusionText or sharpen a forensic outcome, but don't restructure the case.";
+
+        if (!string.IsNullOrEmpty(areaGuidance))
+        {
+            system += "\n\n=== AREA-SPECIFIC PLAYBOOKS ===\nThe red-team flagged issues in the following areas. Apply the matching playbook precisely — these are the highest-leverage edits for getting the case promoted to `ok`.\n" + areaGuidance;
+        }
+
+        if (isRookie)
+        {
+            system += @"
+
+=== ROOKIE CONTEXT ===
+This case is a **Rookie** training case. The refine loop will run only once, so this is your single opportunity to clear the medium-severity findings. Be **decisive**, not surgical:
+- If a Timeline event contradicts the briefing or another event, **pick the version implied by the solution and rewrite the conflicting prose**. Do not leave both versions in place.
+- If a SmokingGun finding says the evidence is ambiguous, **add concrete corroborating detail to the evidence asset itself** (a timestamp, a fresh-print marker, a witness reference) AND mirror that detail in the corresponding ConclusionText / solution reasoning.
+- If a Question presupposes a fact the dossier does not show, **either rewrite the question to ask only what the evidence supports, or add the missing fact to the supporting asset**.
+- Do not invent new suspects, new locations, or new red herrings. Modify existing prose only.";
+        }
 
         var user = $@"=== CURRENT case.json ===
 {currentJson}
@@ -98,5 +119,91 @@ Emit the corrected case.json as a single JSON object.";
             _logger.LogWarning(ex, "RefineCaseTask failed");
             return new Result { Error = ex.Message };
         }
+    }
+
+    /// <summary>
+    /// Inspect the findings to detect which high-leverage areas were flagged, then emit a
+    /// concrete playbook for each. This is the single biggest lever for clearing medium
+    /// findings on a Rookie case in one refine pass — generic "be surgical" guidance is
+    /// not enough when the LLM has to choose between rephrasing prose vs. fixing logic.
+    /// </summary>
+    private static string BuildAreaGuidance(IReadOnlyList<RedTeamTask.Finding> findings)
+    {
+        var actionable = findings
+            .Where(f => !string.Equals(f.Severity, "low", StringComparison.OrdinalIgnoreCase))
+            .Select(f => NormalizeArea(f.Area))
+            .Where(a => !string.IsNullOrEmpty(a))
+            .ToHashSet();
+        if (actionable.Count == 0) return string.Empty;
+
+        var sb = new System.Text.StringBuilder();
+
+        if (actionable.Contains("timeline"))
+        {
+            sb.AppendLine(@"
+[Timeline]
+- Two events with conflicting timestamps or contradictory descriptions MUST be reconciled. Pick the version implied by the solution (or by the briefing if the solution is silent) and rewrite OR delete the conflicting event.
+- Every timeline event with a specific time should be anchored by something visible to the player — an asset, a witness statement, or a forensic outcome. If no anchor exists, either add a brief source attribution in the event description or remove the precise time.
+- Verify `openedAt`, the briefing prose, and every `timelineEvents[].at` align on date AND hour. A discrepancy here is the #1 cause of `needs_review`.
+- When you change an event time, also update any narrative text (briefing, asset descriptions, ConclusionText) that referenced the old time.");
+        }
+
+        if (actionable.Contains("smokinggun"))
+        {
+            sb.AppendLine(@"
+[SmokingGun]
+- The conclusive evidence must be hard to explain away. If a finding says the smoking gun is ambiguous, add ONE of these concrete enhancements to the underlying evidence asset (and mirror it in `solution.conclusionText` / forensic outcome text):
+  (a) **Recency marker**: ""trace fraîche"" / ""prelevamento recente"" / fresh deposit / timestamp from sensor / CCTV frame at HH:MM.
+  (b) **Exclusive signature**: a unique characteristic that only the culprit could have left (an unusual substance, a personal item, a biometric tied to a verified profile).
+  (c) **Independent corroboration**: a second asset (witness, sensor log, transaction record) that places the same person/object at the same time.
+- Do NOT add new suspects, new locations, or new high-level plot beats. The fix is always at the level of evidence detail, not story structure.");
+        }
+
+        if (actionable.Contains("questions"))
+        {
+            sb.AppendLine(@"
+[Questions]
+- Every question's correct answer MUST be directly derivable from the assets the player can read. If a question presupposes a fact (""quel canal a permis..."", ""qual foi o motivo..."") the dossier MUST contain an asset that states that fact in plain prose.
+- Two valid fixes:
+  (1) **Add the missing fact** to the supporting asset description / ConclusionText (preferred — preserves the question).
+  (2) **Rephrase the question** so the presupposition becomes part of the question (""sachant que la porte arrière était compatible, qui...""), or downgrade it to ask only what the evidence supports.
+- Never leave a question whose correct answer requires the player to guess between equally-supported options.");
+        }
+
+        if (actionable.Contains("requiredevidence"))
+        {
+            sb.AppendLine(@"
+[RequiredEvidence]
+- Every id in `solution.requiredEvidenceIds` MUST resolve to an asset the player can actually obtain. Two valid shapes:
+  (1) The id matches an entry in `assets[]` whose visibility makes it readable in the player's flow.
+  (2) The id matches an asset produced by a forensic outcome (and that forensic input/outcome chain is reachable).
+- If a referenced id does not exist, either add the missing asset (preferred) or replace the id with the closest existing asset id and update all other references consistently.
+- Do not silently drop an id from `requiredEvidenceIds` unless the solution genuinely no longer depends on it.");
+        }
+
+        if (actionable.Contains("forensics"))
+        {
+            sb.AppendLine(@"
+[Forensics]
+- Every forensic outcome must (a) name the specific input asset it consumed, (b) describe a concrete observation (not an authority claim like ""présence détectée""), and (c) produce an output asset id that exists in `assets[]` or is added by this refine.
+- Replace vague phrases (""compatible"", ""présence à proximité"", ""possibly linked"") with concrete observations (cell-ID + sector, timestamp, distinguishing mark).");
+        }
+
+        if (actionable.Contains("decoys"))
+        {
+            sb.AppendLine(@"
+[Decoys]
+- Each decoy suspect needs an alibi the player can VERIFY from a visible asset (CCTV log, transaction record, GPS trace), not just a narrative claim.
+- If an alibi is described as ""confirmed by video/CB/GPS"" but no such asset is in `assets[]`, add the minimal supporting asset OR weaken the alibi prose so it doesn't promise verification that doesn't exist.");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string NormalizeArea(string? area)
+    {
+        if (string.IsNullOrWhiteSpace(area)) return string.Empty;
+        // Red-team uses both "Smoking-gun"/"SmokingGun" and "Required-evidence"/"RequiredEvidence".
+        return new string(area.ToLowerInvariant().Where(char.IsLetterOrDigit).ToArray());
     }
 }


### PR DESCRIPTION
## Context

Follow-up to #157. With #157 deployed, Rookie cases now stop the refine loop after 1 iteration and the RedTeam logs each finding individually. The case **Le Dernier Expresso** (job `casev2-20260526171822-a416ca`) showed the real remaining problem:

- Initial RedTeam: `needs_review` (3 medium + 3 low) ✅ no longer `reject`
- Refine iteration 1 ran, accepted
- Re-audit: `needs_review` (3 medium + 3 low) — **same areas, same findings**
- Loop plateaued

The 3 mediums were legitimate (not nitpicking):
1. **SmokingGun** — fingerprint on a mug handle isn''t conclusive without dating
2. **Timeline** — "first responders 22:55" contradicts briefing "discovered next morning"
3. **Questions** — Q3 presupposes the back door was the channel but evidence only says "compatible"

The refine task rephrased prose but didn''t fix the underlying logic.

## What this PR does

Teaches `RefineCaseTask` to:
1. **Detect which areas were flagged** (case-insensitive, handles `Smoking-gun`/`SmokingGun`, `Required-evidence`/`RequiredEvidence`).
2. **Inject an area-specific playbook** into the system prompt for each flagged area, with concrete edit recipes.
3. For **Rookie** difficulty, append a "be decisive, not surgical" block (the Rookie refine cap is 1 iteration — no second chance).

Playbooks added:
| Area | Edit recipe (summary) |
|---|---|
| Timeline | Reconcile contradictions, anchor times to sources, align `openedAt`/briefing/`timelineEvents` |
| SmokingGun | Add recency marker, exclusive signature, or independent corroboration to the evidence asset |
| Questions | Either add missing fact to supporting asset, or rephrase question |
| RequiredEvidence | Every id must resolve to an obtainable asset |
| Forensics | Replace authority claims with concrete observations |
| Decoys | Alibis described as verifiable must have the verifying asset |

`difficulty` is plumbed from `CaseV2GeneratorService` through to `RefineCaseTask` via a new optional parameter (no breaking changes to existing callers).

## Tests
- `dotnet build` — 0 warnings / 0 errors
- `dotnet test` — 20/20 passing

## Files
- `functions/CaseGen.Functions/Services/CaseV2/Tasks/RefineCaseTask.cs` — area detection + playbooks + Rookie block
- `functions/CaseGen.Functions/Services/CaseV2/CaseV2GeneratorService.cs` — pass `difficulty` to refine

## Validation plan
After merge + deploy, generate a fresh Rookie case and check that:
- Findings of area Timeline/SmokingGun/Questions either disappear OR drop to severity `low` after refine
- Verdict promotes to `ok` (with `PromoteRookieVerdict` from #157 handling residual ≤2 mediums)